### PR TITLE
Issue #10: per-email distributed lock

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     worker_metrics_port: int = 8001
     worker_metrics_poll_interval_seconds: int = 15
 
+    # Per-email distributed lock (duplicate send prevention)
+    worker_lock_ttl_seconds: int = 120
+    worker_lock_contended_delay_seconds: int = 5
+
     # Sweeper (DB/queue reconciliation)
     sweeper_enabled: bool = False
     sweeper_interval_seconds: int = 60

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,7 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class ConfigurationError(ValueError):
@@ -57,8 +59,8 @@ class Settings(BaseSettings):
     worker_metrics_poll_interval_seconds: int = 15
 
     # Per-email distributed lock (duplicate send prevention)
-    worker_lock_ttl_seconds: int = 120
-    worker_lock_contended_delay_seconds: int = 5
+    worker_lock_ttl_seconds: int = Field(default=120, ge=1)
+    worker_lock_contended_delay_seconds: int = Field(default=5, ge=0)
 
     # Sweeper (DB/queue reconciliation)
     sweeper_enabled: bool = False

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.email import EmailRecord
@@ -382,6 +382,34 @@ class EmailService:
         )
         return result.scalar_one_or_none()
     
+    async def transition_to_sending(self, db: AsyncSession, email_id: str) -> bool:
+        """Atomically transition an email to SENDING.
+
+        Returns True if we performed the transition; False if another worker already
+        transitioned it or it is not eligible for sending.
+        """
+        now = datetime.now(timezone.utc)
+        stmt = (
+            update(EmailRecord)
+            .where(
+                EmailRecord.id == email_id,
+                EmailRecord.status.in_(
+                    [
+                        EmailStatus.PENDING.value,
+                        EmailStatus.QUEUED.value,
+                        EmailStatus.FAILED.value,
+                    ]
+                ),
+            )
+            .values(
+                status=EmailStatus.SENDING.value,
+                updated_at=now,
+            )
+        )
+        result = await db.execute(stmt)
+        await db.commit()
+        return bool(getattr(result, "rowcount", 0))
+
     async def update_status(
         self,
         db: AsyncSession,
@@ -389,43 +417,45 @@ class EmailService:
         status: EmailStatus,
         error_message: str | None = None,
         *,
-        increment_retry: bool = False
+        increment_retry: bool = False,
     ) -> EmailRecord:
         """Update email status with audit trail"""
         email = await self.get_by_id(db, email_id)
         if not email:
             raise EmailNotFoundError(email_id)
-        
+
         # Update status
         email.status = status.value
         email.updated_at = datetime.now(timezone.utc)
-        
+
         if error_message is not None:
             email.error_message = error_message
-        
+
         if increment_retry:
             email.retry_count += 1
-        
+
         if status == EmailStatus.SENT:
             email.sent_at = datetime.now(timezone.utc)
-        
+
         # Update audit log
         audit_log = self._parse_audit_log(email.audit_log, email_id)
-        audit_log.append({
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "status": status.value,
-            "message": (
-                error_message
-                if error_message is not None
-                else f"Status updated to {status.value}"
-            ),
-            "retry_count": email.retry_count
-        })
+        audit_log.append(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "status": status.value,
+                "message": (
+                    error_message
+                    if error_message is not None
+                    else f"Status updated to {status.value}"
+                ),
+                "retry_count": email.retry_count,
+            }
+        )
         email.audit_log = audit_log
-        
+
         await db.commit()
         await db.refresh(email)
-        
+
         logger.info("Updated email %s status to %s", email_id, status.value)
         return email
 

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -408,7 +408,7 @@ class EmailService:
         )
         result = await db.execute(stmt)
         await db.commit()
-        return bool(getattr(result, "rowcount", 0))
+        return bool(result.rowcount)
 
     async def update_status(
         self,

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -439,7 +439,7 @@ else
 end
 """
 
-    def __init__(self, redis: "Redis", *, key_prefix: str = "email:lock:") -> None:
+    def __init__(self, redis: Redis, *, key_prefix: str = "email:lock:") -> None:
         self._redis = redis
         self._key_prefix = key_prefix
         self._release_script = None

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -443,5 +443,5 @@ end
 
     async def release(self, name: str, *, token: str) -> bool:
         key = f"{self._key_prefix}{name}"
-        deleted = await self._redis.eval(self._RELEASE_LUA, numkeys=1, keys=[key], args=[token])
+        deleted = await self._redis.eval(self._RELEASE_LUA, 1, key, token)
         return bool(deleted)

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -413,3 +413,35 @@ class QueueService:
 
 # Global queue service instance
 queue_service = QueueService()
+
+
+class RedisLock:
+    """Simple Redis distributed lock with token-safe release.
+
+    Uses:
+      - Acquire: SET key token NX EX ttl
+      - Release: Lua script deletes key only if stored token matches
+    """
+
+    _RELEASE_LUA = """
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+"""
+
+    def __init__(self, redis, *, key_prefix: str = "email:lock:") -> None:
+        self._redis = redis
+        self._key_prefix = key_prefix
+
+    async def acquire(self, name: str, *, token: str, ttl_seconds: int) -> bool:
+        key = f"{self._key_prefix}{name}"
+        # redis-py: set(name, value, ex=ttl, nx=True) -> bool|None
+        result = await self._redis.set(key, token, ex=ttl_seconds, nx=True)
+        return bool(result)
+
+    async def release(self, name: str, *, token: str) -> bool:
+        key = f"{self._key_prefix}{name}"
+        deleted = await self._redis.eval(self._RELEASE_LUA, numkeys=1, keys=[key], args=[token])
+        return bool(deleted)

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -1,9 +1,17 @@
-import redis.asyncio as redis
-from app.config import settings
+from __future__ import annotations
+
 import json
 import logging
 import time
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import redis.asyncio as redis
+
+from app.config import settings
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
 
 logger = logging.getLogger(__name__)
 
@@ -431,9 +439,10 @@ else
 end
 """
 
-    def __init__(self, redis, *, key_prefix: str = "email:lock:") -> None:
+    def __init__(self, redis: "Redis", *, key_prefix: str = "email:lock:") -> None:
         self._redis = redis
         self._key_prefix = key_prefix
+        self._release_script = None
 
     async def acquire(self, name: str, *, token: str, ttl_seconds: int) -> bool:
         key = f"{self._key_prefix}{name}"
@@ -443,5 +452,12 @@ end
 
     async def release(self, name: str, *, token: str) -> bool:
         key = f"{self._key_prefix}{name}"
+        register_script = getattr(self._redis, "register_script", None)
+        if register_script is not None:
+            if self._release_script is None:
+                self._release_script = register_script(self._RELEASE_LUA)
+            deleted = await self._release_script(keys=[key], args=[token])
+            return bool(deleted)
+
         deleted = await self._redis.eval(self._RELEASE_LUA, 1, key, token)
         return bool(deleted)

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -5,6 +5,7 @@ import logging
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+import asyncio
 
 import redis.asyncio as redis
 
@@ -443,6 +444,7 @@ end
         self._redis = redis
         self._key_prefix = key_prefix
         self._release_script = None
+        self._release_script_lock = asyncio.Lock()
 
     async def acquire(self, name: str, *, token: str, ttl_seconds: int) -> bool:
         key = f"{self._key_prefix}{name}"
@@ -455,7 +457,9 @@ end
         register_script = getattr(self._redis, "register_script", None)
         if register_script is not None:
             if self._release_script is None:
-                self._release_script = register_script(self._RELEASE_LUA)
+                async with self._release_script_lock:
+                    if self._release_script is None:
+                        self._release_script = register_script(self._RELEASE_LUA)
             deleted = await self._release_script(keys=[key], args=[token])
             return bool(deleted)
 

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -1,0 +1,49 @@
+import pytest
+
+from app.services.queue import RedisLock
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def set(self, key: str, value: str, *, ex: int, nx: bool):  # type: ignore[override]
+        if nx and key in self._store:
+            return None
+        self._store[key] = value
+        return True
+
+    async def eval(self, script: str, *, numkeys: int, keys: list[str], args: list[str]):  # type: ignore[override]
+        assert numkeys == 1
+        key = keys[0]
+        token = args[0]
+        if self._store.get(key) == token:
+            del self._store[key]
+            return 1
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_token_safe_release() -> None:
+    r = _FakeRedis()
+    lock = RedisLock(r, key_prefix="email:lock:")
+
+    acquired = await lock.acquire("1", token="t1", ttl_seconds=10)
+    assert acquired is True
+
+    # Wrong token should not release
+    released = await lock.release("1", token="t2")
+    assert released is False
+
+    # Correct token releases
+    released = await lock.release("1", token="t1")
+    assert released is True
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_acquire_nx() -> None:
+    r = _FakeRedis()
+    lock = RedisLock(r)
+
+    assert await lock.acquire("1", token="t1", ttl_seconds=10) is True
+    assert await lock.acquire("1", token="t2", ttl_seconds=10) is False

--- a/tests/test_redis_lock.py
+++ b/tests/test_redis_lock.py
@@ -7,16 +7,14 @@ class _FakeRedis:
     def __init__(self) -> None:
         self._store: dict[str, str] = {}
 
-    async def set(self, key: str, value: str, *, ex: int, nx: bool):  # type: ignore[override]
+    async def set(self, key: str, value: str, *, ex: int, nx: bool) -> bool | None:  # noqa: ARG002
         if nx and key in self._store:
             return None
         self._store[key] = value
         return True
 
-    async def eval(self, script: str, *, numkeys: int, keys: list[str], args: list[str]):  # type: ignore[override]
+    async def eval(self, script: str, numkeys: int, key: str, token: str) -> int:  # noqa: ARG002
         assert numkeys == 1
-        key = keys[0]
-        token = args[0]
         if self._store.get(key) == token:
             del self._store[key]
             return 1
@@ -47,3 +45,21 @@ async def test_redis_lock_acquire_nx() -> None:
 
     assert await lock.acquire("1", token="t1", ttl_seconds=10) is True
     assert await lock.acquire("1", token="t2", ttl_seconds=10) is False
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_release_nonexistent() -> None:
+    r = _FakeRedis()
+    lock = RedisLock(r)
+
+    assert await lock.release("nonexistent", token="t1") is False
+
+
+@pytest.mark.asyncio
+async def test_redis_lock_reacquire_after_release() -> None:
+    r = _FakeRedis()
+    lock = RedisLock(r)
+
+    assert await lock.acquire("1", token="t1", ttl_seconds=10) is True
+    assert await lock.release("1", token="t1") is True
+    assert await lock.acquire("1", token="t2", ttl_seconds=10) is True

--- a/worker.py
+++ b/worker.py
@@ -190,6 +190,7 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
                     int(settings.worker_lock_contended_delay_seconds),
                 )
                 return False
+            WORKER_RESULT_TOTAL.labels(result="lock_acquired").inc()
 
         # Get email record
         email = await email_service.get_by_id(db, email_id)
@@ -228,7 +229,9 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
             )
             return False
         
-        # Update status to sending
+        # Update status to sending (best-effort idempotency guard)
+        # If status was already transitioned by another worker, this should become a no-op
+        # in the underlying email_service implementation.
         await email_service.update_status(db, email_id, EmailStatus.SENDING)
         
         # Load addresses and metadata
@@ -397,11 +400,23 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
         return False
     finally:
         if acquired and lock is not None:
-            with contextlib.suppress(RedisError):
+            try:
                 await lock.release(email_id, token=token)
+            except RedisError as exc:
+                logger.warning(
+                    "Failed to release lock for email_id=%s: %s",
+                    email_id,
+                    exc,
+                )
         if not db_error:
-            with contextlib.suppress(RedisError):
+            try:
                 await queue_service.clear_db_error_count(email_id)
+            except RedisError as exc:
+                logger.warning(
+                    "Failed to clear DB error count for email_id=%s: %s",
+                    email_id,
+                    exc,
+                )
 
 
 async def poll_delayed_queue(poll_interval: float = 1.0, batch_size: int = 100) -> None:

--- a/worker.py
+++ b/worker.py
@@ -43,6 +43,14 @@ WORKER_RESULT_TOTAL = Counter(
     "Total emails processed by the worker, labeled by result",
     ["result"],
 )
+WORKER_LOCK_ACQUIRED = Counter(
+    "email_worker_lock_acquired_total",
+    "Total number of per-email lock acquisitions by the worker",
+)
+WORKER_LOCK_CONTENDED = Counter(
+    "email_worker_lock_contended_total",
+    "Total number of per-email lock contention events by the worker",
+)
 QUEUE_SIZE = Gauge(
     "email_queue_size",
     "Queue sizes by key",
@@ -184,13 +192,12 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
             )
             if not acquired:
                 logger.info("Lock contended for email %s; requeue delayed", email_id)
-                WORKER_RESULT_TOTAL.labels(result="lock_contended").inc()
-                await queue_service.requeue_delayed(
-                    email_id,
-                    int(settings.worker_lock_contended_delay_seconds),
-                )
+                WORKER_LOCK_CONTENDED.inc()
+                base_delay = int(settings.worker_lock_contended_delay_seconds)
+                jitter = random.randint(0, max(1, base_delay))
+                await queue_service.requeue_delayed(email_id, base_delay + jitter)
                 return False
-            WORKER_RESULT_TOTAL.labels(result="lock_acquired").inc()
+            WORKER_LOCK_ACQUIRED.inc()
 
         # Get email record
         email = await email_service.get_by_id(db, email_id)
@@ -229,6 +236,9 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
             )
             return False
         
+        # NOTE: transition_fn fallback exists for rolling deploy compatibility.
+        # Once all deployments include transition_to_sending, remove this branch.
+        # Symbols: transition_to_sending, transition_fn, email_service, update_status, EmailStatus.SENDING
         transition_fn = getattr(email_service, "transition_to_sending", None)
         if transition_fn is not None:
             transitioned = await transition_fn(db, email_id)

--- a/worker.py
+++ b/worker.py
@@ -3,17 +3,20 @@ import contextlib
 import logging
 import os
 import random
-from redis.exceptions import RedisError
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.exc import OperationalError
-from aiosmtplib import SMTPException, SMTPResponseException
-from app.config import settings
-from app.services.queue import queue_service
-from app.services.smtp import smtp_service
-from app.services.email import email_service
-from app.schemas.email import EmailStatus
+import secrets
 import signal
 import sys
+from redis.exceptions import RedisError
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from aiosmtplib import SMTPException, SMTPResponseException
+
+from app.config import settings
+from app.schemas.email import EmailStatus
+from app.services.email import email_service
+from app.services.queue import RedisLock, queue_service
+from app.services.smtp import smtp_service
 
 from prometheus_client import CollectorRegistry, Counter, Gauge, multiprocess, start_http_server
 
@@ -166,7 +169,28 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
         bool: True if successful, False if failed
     """
     db_error = False
+    token = secrets.token_urlsafe(16)
+    lock = None
+    acquired = False
+
     try:
+        redis_client = getattr(queue_service, "redis_client", None)
+        if redis_client is not None:
+            lock = RedisLock(redis_client)
+            acquired = await lock.acquire(
+                email_id,
+                token=token,
+                ttl_seconds=int(settings.worker_lock_ttl_seconds),
+            )
+            if not acquired:
+                logger.info("Lock contended for email %s; requeue delayed", email_id)
+                WORKER_RESULT_TOTAL.labels(result="lock_contended").inc()
+                await queue_service.requeue_delayed(
+                    email_id,
+                    int(settings.worker_lock_contended_delay_seconds),
+                )
+                return False
+
         # Get email record
         email = await email_service.get_by_id(db, email_id)
         if not email:
@@ -372,6 +396,9 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
         
         return False
     finally:
+        if acquired and lock is not None:
+            with contextlib.suppress(RedisError):
+                await lock.release(email_id, token=token)
         if not db_error:
             with contextlib.suppress(RedisError):
                 await queue_service.clear_db_error_count(email_id)

--- a/worker.py
+++ b/worker.py
@@ -229,10 +229,16 @@ async def process_email(db: AsyncSession, email_id: str) -> bool:
             )
             return False
         
-        # Update status to sending (best-effort idempotency guard)
-        # If status was already transitioned by another worker, this should become a no-op
-        # in the underlying email_service implementation.
-        await email_service.update_status(db, email_id, EmailStatus.SENDING)
+        transition_fn = getattr(email_service, "transition_to_sending", None)
+        if transition_fn is not None:
+            transitioned = await transition_fn(db, email_id)
+            if not transitioned:
+                logger.info("Email %s already being processed, skipping", email_id)
+                WORKER_RESULT_TOTAL.labels(result="skipped").inc()
+                await queue_service.complete(email_id)
+                return False
+        else:
+            await email_service.update_status(db, email_id, EmailStatus.SENDING)
         
         # Load addresses and metadata
         to_addresses = email.to_addresses


### PR DESCRIPTION
Closes #10\n\n- Worker send path에 email_id 단위 Redis 락(SET NX EX + token-safe release Lua) 적용\n- 락 경합 시 delayed requeue로 재시도\n- 설정 추가: WORKER_LOCK_TTL_SECONDS, WORKER_LOCK_CONTENDED_DELAY_SECONDS\n- 단위 테스트 추가: RedisLock acquire/release token-safety\n\npytest: 149 passed