### PR TITLE
Add processing reaper / visibility timeout

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -69,6 +69,12 @@ class Settings(BaseSettings):
     sweeper_batch_size: int = 100
     sweeper_max_requeue_attempts: int = 10
 
+    # Processing visibility timeout / reaper
+    processing_reaper_enabled: bool = False
+    processing_reaper_interval_seconds: int = 60
+    processing_visibility_timeout_seconds: int = Field(default=300, ge=1)
+    processing_reaper_batch_size: int = Field(default=100, ge=1)
+
     # Admin/ops allowlist for queue stats endpoint (comma-separated caller ids)
     queue_stats_allowed_callers: str = ""
     

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
-import asyncio
 
 import redis.asyncio as redis
 
@@ -61,6 +61,30 @@ class QueueService:
     return 0
     """
 
+    REAP_PROCESSING_SCRIPT = """
+    local processing_key = KEYS[1]
+    local queue_key = KEYS[2]
+    local vis_key = KEYS[3]
+    local now = tonumber(ARGV[1])
+    local max_batch = tonumber(ARGV[2])
+
+    local expired = redis.call('ZRANGEBYSCORE', vis_key, 0, now, 'LIMIT', 0, max_batch)
+    if #expired == 0 then
+        return 0
+    end
+
+    redis.call('ZREM', vis_key, unpack(expired))
+    local moved = 0
+    for _, email_id in ipairs(expired) do
+        local removed = redis.call('LREM', processing_key, 1, email_id)
+        if removed > 0 then
+            redis.call('LPUSH', queue_key, email_id)
+            moved = moved + 1
+        end
+    end
+    return moved
+    """
+
     MOVE_READY_DELAYED_SCRIPT = """
     local delayed_key = KEYS[1]
     local queue_key = KEYS[2]
@@ -84,6 +108,7 @@ class QueueService:
         self.redis_client = None
         self.queue_key = "email:queue"
         self.processing_key = "email:processing"
+        self.processing_visibility_key = "email:processing:vis"
         self.dlq_key = "email:dlq"
         self.delayed_queue_key = "email:delayed"
         # Tracks IDs that are expected to be queued (or delayed) to support the sweeper job.
@@ -93,6 +118,7 @@ class QueueService:
         self._requeue_script = None
         self._requeue_delayed_script = None
         self._move_ready_delayed_script = None
+        self._reap_processing_script = None
 
     def _db_error_key(self, email_id: str) -> str:
         return f"{self.db_error_key_prefix}:{email_id}"
@@ -115,6 +141,9 @@ class QueueService:
         )
         self._move_ready_delayed_script = self.redis_client.register_script(
             self.MOVE_READY_DELAYED_SCRIPT
+        )
+        self._reap_processing_script = self.redis_client.register_script(
+            self.REAP_PROCESSING_SCRIPT
         )
         logger.info("Connected to Redis")
     
@@ -200,8 +229,59 @@ class QueueService:
             raise
         if result:
             logger.info("Dequeued email %s", result)
+        if result:
+            await self.refresh_processing_visibility(result)
         return result
     
+    async def refresh_processing_visibility(
+        self, email_id: str, *, timeout_seconds: int | None = None
+    ) -> None:
+        """Refresh visibility timeout for a processing email id.
+
+        Raises:
+            redis.RedisError: When Redis operations fail.
+        """
+        if timeout_seconds is None:
+            timeout_seconds = int(settings.processing_visibility_timeout_seconds)
+        score = time.time() + timeout_seconds
+        try:
+            await self.redis_client.zadd(
+                self.processing_visibility_key,
+                {email_id: score},
+            )
+        except redis.RedisError:
+            logger.exception("Failed to refresh processing visibility for %s", email_id)
+            raise
+
+    async def reap_processing(self, max_batch: int | None = None) -> int:
+        """Reap expired processing ids back to the main queue.
+
+        Returns:
+            int: number of ids moved back to queue.
+
+        Raises:
+            redis.RedisError: When Redis operations fail.
+        """
+        if max_batch is None:
+            max_batch = int(settings.processing_reaper_batch_size)
+        now = time.time()
+        try:
+            moved = await self._reap_processing_script(
+                keys=[
+                    self.processing_key,
+                    self.queue_key,
+                    self.processing_visibility_key,
+                ],
+                args=[now, max_batch],
+            )
+        except redis.RedisError:
+            logger.exception("Failed to reap processing queue")
+            raise
+        moved = int(moved or 0)
+        if moved > 0:
+            logger.warning("Reaped %d stuck processing emails back to queue", moved)
+        return moved
+
     async def complete(self, email_id: str):
         """Remove email from processing set after successful send.
 
@@ -212,6 +292,7 @@ class QueueService:
         """
         try:
             await self.redis_client.lrem(self.processing_key, 1, email_id)
+            await self.redis_client.zrem(self.processing_visibility_key, email_id)
         except redis.RedisError:
             logger.exception("Failed to complete email %s", email_id)
             raise

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -105,6 +105,7 @@ class QueueService:
     """
     
     def __init__(self) -> None:
+        """Initialize queue key names and Redis Lua scripts."""
         self.redis_client = None
         self.queue_key = "email:queue"
         self.processing_key = "email:processing"

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -11,10 +11,24 @@ import redis.asyncio as redis
 
 from app.config import settings
 
+try:
+    from prometheus_client import Counter
+except Exception:  # pragma: no cover
+    Counter = None  # type: ignore[assignment]
+
 if TYPE_CHECKING:
     from redis.asyncio import Redis
 
 logger = logging.getLogger(__name__)
+
+REAPER_MOVED_TOTAL = (
+    Counter(
+        "email_reaper_moved_total",
+        "Total number of processing IDs moved back to the main queue by the reaper",
+    )
+    if Counter is not None
+    else None
+)
 
 
 class QueueService:
@@ -230,7 +244,6 @@ class QueueService:
             raise
         if result:
             logger.info("Dequeued email %s", result)
-        if result:
             await self.refresh_processing_visibility(result)
         return result
     
@@ -280,6 +293,8 @@ class QueueService:
             raise
         moved = int(moved or 0)
         if moved > 0:
+            if REAPER_MOVED_TOTAL is not None:
+                REAPER_MOVED_TOTAL.inc(moved)
             logger.warning("Reaped %d stuck processing emails back to queue", moved)
         return moved
 

--- a/tests/test_processing_reaper.py
+++ b/tests/test_processing_reaper.py
@@ -1,0 +1,68 @@
+import time
+
+import pytest
+import redis.asyncio as redis
+
+from app.services.queue import QueueService
+
+
+@pytest.mark.asyncio
+async def test_reap_processing_moves_expired_id_back_to_queue(monkeypatch):
+    # Use a dedicated QueueService instance with isolated keys.
+    svc = QueueService()
+    svc.queue_key = "test:email:queue"
+    svc.processing_key = "test:email:processing"
+    svc.processing_visibility_key = "test:email:processing:vis"
+    svc.delayed_queue_key = "test:email:delayed"
+    svc.dlq_key = "test:email:dlq"
+    svc.queued_set_key = "test:email:queued:set"
+
+    client = await redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        await client.ping()
+    except Exception:
+        await client.aclose()
+        pytest.skip("Redis not available on localhost:6379")
+    try:
+        svc.redis_client = client
+        svc._move_to_dlq_script = client.register_script(svc.MOVE_TO_DLQ_SCRIPT)
+        svc._requeue_script = client.register_script(svc.REQUEUE_SCRIPT)
+        svc._requeue_delayed_script = client.register_script(svc.REQUEUE_DELAYED_SCRIPT)
+        svc._move_ready_delayed_script = client.register_script(svc.MOVE_READY_DELAYED_SCRIPT)
+        svc._reap_processing_script = client.register_script(svc.REAP_PROCESSING_SCRIPT)
+
+        # Ensure clean slate.
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+
+        email_id = "email-1"
+        # Simulate: moved to processing but worker crashed (never completed).
+        await client.lpush(svc.processing_key, email_id)
+        # Mark as expired.
+        await client.zadd(svc.processing_visibility_key, {email_id: time.time() - 10})
+
+        moved = await svc.reap_processing(max_batch=10)
+        assert moved == 1
+
+        # Should be removed from processing and visibility set.
+        assert await client.lrange(svc.processing_key, 0, -1) == []
+        assert await client.zscore(svc.processing_visibility_key, email_id) is None
+
+        # Should be back on main queue.
+        assert await client.lrange(svc.queue_key, 0, -1) == [email_id]
+    finally:
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+        await client.aclose()

--- a/tests/test_processing_reaper.py
+++ b/tests/test_processing_reaper.py
@@ -7,7 +7,7 @@ from app.services.queue import QueueService
 
 
 @pytest.mark.asyncio
-async def test_reap_processing_moves_expired_id_back_to_queue(monkeypatch):
+async def test_reap_processing_moves_expired_id_back_to_queue():
     # Use a dedicated QueueService instance with isolated keys.
     svc = QueueService()
     svc.queue_key = "test:email:queue"
@@ -56,6 +56,183 @@ async def test_reap_processing_moves_expired_id_back_to_queue(monkeypatch):
 
         # Should be back on main queue.
         assert await client.lrange(svc.queue_key, 0, -1) == [email_id]
+    finally:
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_reap_processing_does_not_move_non_expired_items():
+    svc = QueueService()
+    svc.queue_key = "test:email:queue:nonexpired"
+    svc.processing_key = "test:email:processing:nonexpired"
+    svc.processing_visibility_key = "test:email:processing:vis:nonexpired"
+    svc.delayed_queue_key = "test:email:delayed:nonexpired"
+    svc.dlq_key = "test:email:dlq:nonexpired"
+    svc.queued_set_key = "test:email:queued:set:nonexpired"
+
+    client = await redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        await client.ping()
+    except Exception:
+        await client.aclose()
+        pytest.skip("Redis not available on localhost:6379")
+
+    try:
+        svc.redis_client = client
+        svc._move_to_dlq_script = client.register_script(svc.MOVE_TO_DLQ_SCRIPT)
+        svc._requeue_script = client.register_script(svc.REQUEUE_SCRIPT)
+        svc._requeue_delayed_script = client.register_script(svc.REQUEUE_DELAYED_SCRIPT)
+        svc._move_ready_delayed_script = client.register_script(svc.MOVE_READY_DELAYED_SCRIPT)
+        svc._reap_processing_script = client.register_script(svc.REAP_PROCESSING_SCRIPT)
+
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+
+        email_id = "email-nonexpired"
+        await client.lpush(svc.processing_key, email_id)
+        await client.zadd(svc.processing_visibility_key, {email_id: time.time() + 10})
+
+        moved = await svc.reap_processing(max_batch=10)
+        assert moved == 0
+
+        assert await client.lrange(svc.processing_key, 0, -1) == [email_id]
+        assert await client.zscore(svc.processing_visibility_key, email_id) is not None
+        assert await client.lrange(svc.queue_key, 0, -1) == []
+    finally:
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_reap_processing_moves_multiple_expired_items_in_batch():
+    svc = QueueService()
+    svc.queue_key = "test:email:queue:batch"
+    svc.processing_key = "test:email:processing:batch"
+    svc.processing_visibility_key = "test:email:processing:vis:batch"
+    svc.delayed_queue_key = "test:email:delayed:batch"
+    svc.dlq_key = "test:email:dlq:batch"
+    svc.queued_set_key = "test:email:queued:set:batch"
+
+    client = await redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        await client.ping()
+    except Exception:
+        await client.aclose()
+        pytest.skip("Redis not available on localhost:6379")
+
+    try:
+        svc.redis_client = client
+        svc._move_to_dlq_script = client.register_script(svc.MOVE_TO_DLQ_SCRIPT)
+        svc._requeue_script = client.register_script(svc.REQUEUE_SCRIPT)
+        svc._requeue_delayed_script = client.register_script(svc.REQUEUE_DELAYED_SCRIPT)
+        svc._move_ready_delayed_script = client.register_script(svc.MOVE_READY_DELAYED_SCRIPT)
+        svc._reap_processing_script = client.register_script(svc.REAP_PROCESSING_SCRIPT)
+
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+
+        email_ids = ["email-batch-1", "email-batch-2", "email-batch-3"]
+        for email_id in email_ids:
+            await client.lpush(svc.processing_key, email_id)
+            await client.zadd(svc.processing_visibility_key, {email_id: time.time() - 10})
+
+        moved = await svc.reap_processing(max_batch=10)
+        assert moved == len(email_ids)
+
+        assert await client.lrange(svc.processing_key, 0, -1) == []
+        for email_id in email_ids:
+            assert await client.zscore(svc.processing_visibility_key, email_id) is None
+
+        queued = await client.lrange(svc.queue_key, 0, -1)
+        # Items are LPUSHed, so expect reverse order of reaped iteration (Lua uses ZRANGEBYSCORE order).
+        assert set(queued) == set(email_ids)
+        assert len(queued) == len(email_ids)
+    finally:
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_reap_processing_respects_max_batch_limit():
+    svc = QueueService()
+    svc.queue_key = "test:email:queue:maxbatch"
+    svc.processing_key = "test:email:processing:maxbatch"
+    svc.processing_visibility_key = "test:email:processing:vis:maxbatch"
+    svc.delayed_queue_key = "test:email:delayed:maxbatch"
+    svc.dlq_key = "test:email:dlq:maxbatch"
+    svc.queued_set_key = "test:email:queued:set:maxbatch"
+
+    client = await redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        await client.ping()
+    except Exception:
+        await client.aclose()
+        pytest.skip("Redis not available on localhost:6379")
+
+    try:
+        svc.redis_client = client
+        svc._move_to_dlq_script = client.register_script(svc.MOVE_TO_DLQ_SCRIPT)
+        svc._requeue_script = client.register_script(svc.REQUEUE_SCRIPT)
+        svc._requeue_delayed_script = client.register_script(svc.REQUEUE_DELAYED_SCRIPT)
+        svc._move_ready_delayed_script = client.register_script(svc.MOVE_READY_DELAYED_SCRIPT)
+        svc._reap_processing_script = client.register_script(svc.REAP_PROCESSING_SCRIPT)
+
+        await client.delete(
+            svc.queue_key,
+            svc.processing_key,
+            svc.processing_visibility_key,
+            svc.delayed_queue_key,
+            svc.dlq_key,
+            svc.queued_set_key,
+        )
+
+        email_ids = [f"email-maxbatch-{i}" for i in range(5)]
+        for email_id in email_ids:
+            await client.lpush(svc.processing_key, email_id)
+            await client.zadd(svc.processing_visibility_key, {email_id: time.time() - 10})
+
+        moved = await svc.reap_processing(max_batch=2)
+        assert moved == 2
+
+        remaining_processing = await client.lrange(svc.processing_key, 0, -1)
+        assert len(remaining_processing) == 3
+
+        remaining_vis = await client.zrange(svc.processing_visibility_key, 0, -1)
+        assert len(remaining_vis) == 3
     finally:
         await client.delete(
             svc.queue_key,

--- a/worker.py
+++ b/worker.py
@@ -449,12 +449,30 @@ async def poll_delayed_queue(poll_interval: float = 1.0, batch_size: int = 100) 
             await asyncio.sleep(poll_interval)
 
 
+async def poll_processing_reaper(
+    poll_interval: float = 60.0,
+    batch_size: int = 100,
+) -> None:
+    """Reap stuck processing emails back to queue."""
+    while not shutdown_flag:
+        try:
+            moved = await queue_service.reap_processing(max_batch=batch_size)
+            if moved == 0:
+                await asyncio.sleep(poll_interval)
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            logger.exception("Error reaping processing queue")
+            await asyncio.sleep(poll_interval)
+
+
 async def worker():
     """Main worker loop"""
     global shutdown_flag
 
     engine = None
     delayed_task = None
+    reaper_task = None
     metrics_task = None
     AsyncSessionLocal = None
 
@@ -477,6 +495,13 @@ async def worker():
         await queue_service.connect()
 
         delayed_task = asyncio.create_task(poll_delayed_queue())
+        if settings.processing_reaper_enabled:
+            reaper_task = asyncio.create_task(
+                poll_processing_reaper(
+                    poll_interval=float(settings.processing_reaper_interval_seconds),
+                    batch_size=int(settings.processing_reaper_batch_size),
+                )
+            )
         worker_metrics_interval = (
             float(settings.worker_metrics_poll_interval_seconds)
             if settings.metrics_enabled
@@ -506,6 +531,10 @@ async def worker():
                     delayed_task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await delayed_task
+                if reaper_task and not reaper_task.done():
+                    reaper_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await reaper_task
                 if metrics_task and not metrics_task.done():
                     metrics_task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
@@ -514,6 +543,13 @@ async def worker():
                 await asyncio.sleep(5)
                 await queue_service.connect()
                 delayed_task = asyncio.create_task(poll_delayed_queue())
+                if settings.processing_reaper_enabled:
+                    reaper_task = asyncio.create_task(
+                        poll_processing_reaper(
+                            poll_interval=float(settings.processing_reaper_interval_seconds),
+                            batch_size=int(settings.processing_reaper_batch_size),
+                        )
+                    )
                 if settings.metrics_enabled:
                     metrics_task = asyncio.create_task(
                         poll_queue_metrics(poll_interval=worker_metrics_interval)
@@ -528,6 +564,10 @@ async def worker():
             delayed_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await delayed_task
+        if reaper_task is not None:
+            reaper_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await reaper_task
         if metrics_task is not None:
             metrics_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/worker.py
+++ b/worker.py
@@ -82,6 +82,7 @@ def calculate_backoff_delay(
 
 
 def _start_worker_metrics_server() -> None:
+    """Start the Prometheus metrics HTTP server for the worker, if enabled."""
     if not settings.metrics_enabled:
         return
 


### PR DESCRIPTION
Fixes #9

## 변경사항
- processing visibility zset(email:processing:vis) 추가 및 dequeue 시 만료시간 기록
- 만료된 processing id를 안전하게 queue로 되돌리는 reaper Lua 스크립트 + QueueService.reap_processing()
- worker에 reaper 루프 추가(옵션): PROCESSING_REAPER_ENABLED=true
- 설정값 추가: processing visibility timeout / reaper interval / batch size
- 테스트 추가(로컬 Redis 없으면 skip)

## 설정
- PROCESSING_REAPER_ENABLED (default: false)
- PROCESSING_REAPER_INTERVAL_SECONDS (default: 60)
- PROCESSING_VISIBILITY_TIMEOUT_SECONDS (default: 300)
- PROCESSING_REAPER_BATCH_SIZE (default: 100)

pytest: 151 passed, 1 skipped