### PR TITLE
CODEOWNERS 추가: 코드 오너 리뷰 규칙 준수

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file defines mandatory reviewers for matching paths.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @HYOSUNG-ITX-AI-Business-Department/ai-service-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,14 @@
 #
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Default owner for all paths.
+* @HYOSUNG-ITX-AI-Business-Department/ai-service-team
+
 # Protect this file and GitHub automation config explicitly.
+# NOTE: CODEOWNERS uses the *last* matching pattern, so the more specific
+# patterns must come after the wildcard.
 /.github/CODEOWNERS @HYOSUNG-ITX-AI-Business-Department/ai-service-team
 /.github/ @HYOSUNG-ITX-AI-Business-Department/ai-service-team
-
-* @HYOSUNG-ITX-AI-Business-Department/ai-service-team
 
 # Example (optional): add more granular owners later.
 # /.github/workflows/ @HYOSUNG-ITX-AI-Business-Department/devops-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,12 @@
 #
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Protect this file and GitHub automation config explicitly.
+/.github/CODEOWNERS @HYOSUNG-ITX-AI-Business-Department/ai-service-team
+/.github/ @HYOSUNG-ITX-AI-Business-Department/ai-service-team
+
 * @HYOSUNG-ITX-AI-Business-Department/ai-service-team
+
+# Example (optional): add more granular owners later.
+# /.github/workflows/ @HYOSUNG-ITX-AI-Business-Department/devops-team
+# /docs/ @HYOSUNG-ITX-AI-Business-Department/docs-team


### PR DESCRIPTION
## Summary
Add `.github/CODEOWNERS` so the repository ruleset’s code-owner review requirement is meaningful.

## Walkthrough (intent)
- Declare `@HYOSUNG-ITX-AI-Business-Department/ai-service-team` as code owner for all paths (`*`).

## Testing
- N/A (no runtime code changes)

Fixes #29