### PR TITLE
Enable workflow_dispatch for CI and CodeQL (Scorecard backfill)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - develop
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
       - develop
   schedule:
     - cron: "20 2 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` to CI and CodeQL workflows so maintainers can manually rerun them on specific refs. This helps backfill check-run evidence used by OpenSSF Scorecard’s CI-Tests/SAST heuristics.

## Walkthrough (intent)
1) Add `workflow_dispatch` to `.github/workflows/ci.yml`.
2) Add `workflow_dispatch` to `.github/workflows/codeql.yml`.
3) Do not relax any branch protections or required checks.

## Testing
- GitHub Actions will validate on the PR.

Fixes #33

@coderabbitai full review