### PR TITLE
docs(security): add OpenSSF Best Practices Badge checklist

### DIFF
--- a/docs/security/OPENSSF_BEST_PRACTICES_BADGE.md
+++ b/docs/security/OPENSSF_BEST_PRACTICES_BADGE.md
@@ -21,7 +21,9 @@ link).
 
 1) Enroll the repository and connect it to GitHub.
 2) Target at least the **Passing** level.
-3) After the project is created, add the badge to `README.md`:
+3) After the project is created, add the badge to `README.md`.
+   Do **not** commit the placeholder `<PROJECT_ID>`; replace it with the actual
+   numeric project ID first.
 
 ```markdown
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<PROJECT_ID>/badge)](
@@ -31,13 +33,27 @@ link).
 
 ## Repository checklist (common items)
 
-These items often help reach **Passing**:
+This section maps common repo items to the OpenSSF Best Practices levels.
 
-- ✅ OSI-approved license file present (`LICENSE`)
-- ✅ Security policy present (`SECURITY.md`)
-- ✅ CI runs on pull requests and default branch (`.github/workflows/*.yml`)
-- ✅ Code review required for protected branches (rulesets)
-- ✅ Dependency update automation (Dependabot)
+Sources:
+
+- Passing criteria: <https://www.bestpractices.dev/en/criteria/0>
+- All levels: <https://www.bestpractices.dev/en/criteria>
+
+### Passing (MUST / required)
+
+- ✅ LICENSE is published in the repo (`LICENSE`) (license location MUST)
+- ✅ Vulnerability reporting process is published (`SECURITY.md`) (MUST)
+- ✅ At least one automated test suite exists and is documented (MUST)
+
+### Passing (SUGGESTED / recommended)
+
+- ✅ Continuous integration runs automated tests (SUGGESTED)
+
+### Silver / Gold (higher levels)
+
+- ✅ Dependency monitoring / update process (e.g., Dependabot) (Silver MUST)
+- ✅ Code review by someone other than the author (Gold MUST)
 
 Potential follow-ups (if required by the badge questionnaire):
 

--- a/docs/security/OPENSSF_BEST_PRACTICES_BADGE.md
+++ b/docs/security/OPENSSF_BEST_PRACTICES_BADGE.md
@@ -1,0 +1,52 @@
+# OpenSSF Best Practices Badge (CII-Best-Practices)
+
+## Goal
+
+OpenSSF Scorecard's **CII-Best-Practices** signal is 0 when a repository is not
+enrolled in the **OpenSSF Best Practices Badge** program.
+
+This repository tracks the enrollment and required follow-ups in the related
+issue.
+
+## Where to enroll
+
+Create a project on bestpractices.dev:
+
+- [https://www.bestpractices.dev/en/projects/new](https://www.bestpractices.dev/en/projects/new)
+
+Once created, the project will have a numeric project ID (needed for the badge
+link).
+
+## Suggested workflow
+
+1) Enroll the repository and connect it to GitHub.
+2) Target at least the **Passing** level.
+3) After the project is created, add the badge to `README.md`:
+
+```markdown
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<PROJECT_ID>/badge)](
+  https://www.bestpractices.dev/projects/<PROJECT_ID>
+)
+```
+
+## Repository checklist (common items)
+
+These items often help reach **Passing**:
+
+- ✅ OSI-approved license file present (`LICENSE`)
+- ✅ Security policy present (`SECURITY.md`)
+- ✅ CI runs on pull requests and default branch (`.github/workflows/*.yml`)
+- ✅ Code review required for protected branches (rulesets)
+- ✅ Dependency update automation (Dependabot)
+
+Potential follow-ups (if required by the badge questionnaire):
+
+- CONTRIBUTING.md and governance/process documentation
+- Code of Conduct
+- Release/versioning policy
+- Vulnerability disclosure expectations (timeline, contact channels)
+
+## Notes
+
+- Enrollment and most questionnaire steps are **manual actions outside git**.
+- Avoid committing any secrets/tokens while integrating badges or links.


### PR DESCRIPTION
## Summary
Add an in-repo checklist/runbook for enrolling in the OpenSSF Best Practices Badge program, which Scorecard uses for the CII-Best-Practices signal.

## Walkthrough (intent)
1) Add `docs/security/OPENSSF_BEST_PRACTICES_BADGE.md` describing enrollment steps and a badge snippet.
2) Keep CI/rulesets unchanged.

## Testing
- `npx -y markdownlint-cli2 docs/security/OPENSSF_BEST_PRACTICES_BADGE.md`

Refs #35

@coderabbitai full review