### PR TITLE
chore: add standardized Strix security scan pipeline

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -1,0 +1,103 @@
+name: Strix Security Scan
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+  schedule:
+    # Nightly scan on protected branches.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: strix-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  strix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Self-test Strix gate script
+        run: bash ./scripts/ci/test_strix_quick_gate.sh
+
+      - name: Gate Strix secrets
+        id: gate
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          if [ -z "$STRIX_LLM" ] || [ -z "$LLM_API_KEY" ]; then
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+            echo 'Strix secrets not configured; skipping.'
+          else
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate GCP credentials
+        id: gcp_gate
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          if [ -n "$GCP_SA_KEY" ]; then
+            echo 'has_gcp=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_gcp=false' >> "$GITHUB_OUTPUT"
+            echo 'GCP credentials not configured; Vertex AI auth will not be available.'
+          fi
+
+      - name: Authenticate to Google Cloud
+        if: steps.gate.outputs.enabled == 'true' && steps.gcp_gate.outputs.has_gcp == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install Strix
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --no-cache-dir "strix-agent==0.7.0" "google-cloud-aiplatform>=1.133.0,<2"
+
+      - name: Run Strix (quick)
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          STRIX_LLM_DEFAULT_PROVIDER: vertex_ai
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          RAW_LLM_API_BASE: ${{ secrets.LLM_API_BASE }}
+          STRIX_VERTEX_FALLBACK_MODELS: "vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash"
+          STRIX_TARGET_PATH: ./
+          STRIX_REASONING_EFFORT: ${{ github.event_name == 'push' && 'low' || 'minimal' }}
+          STRIX_LLM_MAX_RETRIES: 1
+          LLM_TIMEOUT: 90
+          STRIX_MEMORY_COMPRESSOR_TIMEOUT: 10
+          STRIX_ATTEMPT_TIMEOUT_SECONDS: 480
+          STRIX_ATTEMPT_KILL_AFTER_SECONDS: 20
+          STRIX_TRANSIENT_RETRY_PER_MODEL: 2
+          STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 3
+          STRIX_FAIL_ON_MIN_SEVERITY: CRITICAL
+        run: bash ./scripts/ci/strix_quick_gate.sh
+
+      - name: Upload Strix reports artifact
+        if: ${{ always() && !cancelled() && steps.gate.outputs.enabled == 'true' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: strix-reports
+          path: strix_runs/
+          if-no-files-found: warn
+          retention-days: 5

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1,0 +1,589 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_PATH="${STRIX_TARGET_PATH:-./}"
+SCAN_MODE="${STRIX_SCAN_MODE:-quick}"
+STRIX_LOG="$(mktemp)"
+STRIX_REPORTS_DIR="${STRIX_REPORTS_DIR:-strix_runs}"
+DEFAULT_PROVIDER="${STRIX_LLM_DEFAULT_PROVIDER:-}"
+ORIGINAL_LLM_API_BASE="${LLM_API_BASE:-}"
+STRIX_ATTEMPT_TIMEOUT_SECONDS="${STRIX_ATTEMPT_TIMEOUT_SECONDS:-480}"
+STRIX_ATTEMPT_KILL_AFTER_SECONDS="${STRIX_ATTEMPT_KILL_AFTER_SECONDS:-20}"
+STRIX_TRANSIENT_RETRY_PER_MODEL="${STRIX_TRANSIENT_RETRY_PER_MODEL:-0}"
+STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS="${STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS:-3}"
+STRIX_FAIL_ON_MIN_SEVERITY="${STRIX_FAIL_ON_MIN_SEVERITY:-CRITICAL}"
+PREEXISTING_REPORT_DIRS=()
+
+cleanup() {
+	rm -f "$STRIX_LOG"
+}
+trap cleanup EXIT
+
+trim_whitespace() {
+	local value="$1"
+	value="${value#"${value%%[![:space:]]*}"}"
+	value="${value%"${value##*[![:space:]]}"}"
+	echo "$value"
+}
+
+STRIX_LLM="$(trim_whitespace "${STRIX_LLM:-}")"
+if [ -z "$STRIX_LLM" ]; then
+	echo "ERROR: STRIX_LLM is required." >&2
+	exit 2
+fi
+
+LLM_API_KEY="$(trim_whitespace "${LLM_API_KEY:-}")"
+if [ -z "$LLM_API_KEY" ]; then
+	echo "ERROR: LLM_API_KEY is required." >&2
+	exit 2
+fi
+export STRIX_LLM
+export LLM_API_KEY
+
+require_positive_integer() {
+	local value="$1"
+	local label="$2"
+	if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+		echo "ERROR: $label must be a positive integer, got '$value'." >&2
+		exit 2
+	fi
+}
+
+require_non_negative_integer() {
+	local value="$1"
+	local label="$2"
+	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+		echo "ERROR: $label must be a non-negative integer, got '$value'." >&2
+		exit 2
+	fi
+}
+
+severity_rank() {
+	case "${1^^}" in
+	CRITICAL)
+		echo 4
+		;;
+	HIGH)
+		echo 3
+		;;
+	MEDIUM)
+		echo 2
+		;;
+	LOW)
+		echo 1
+		;;
+	INFO | INFORMATIONAL | NONE)
+		echo 0
+		;;
+	*)
+		echo -1
+		;;
+	esac
+}
+
+capture_preexisting_report_dirs() {
+	local run_dir
+	for run_dir in "$STRIX_REPORTS_DIR"/*; do
+		if [ ! -d "$run_dir" ]; then
+			continue
+		fi
+		PREEXISTING_REPORT_DIRS+=("$run_dir")
+	done
+}
+
+is_preexisting_report_dir() {
+	local candidate="$1"
+	local existing
+
+	for existing in "${PREEXISTING_REPORT_DIRS[@]}"; do
+		if [ "$candidate" = "$existing" ]; then
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+resolve_timeout_bin() {
+	if command -v timeout >/dev/null 2>&1; then
+		echo "timeout"
+		return 0
+	fi
+
+	if command -v gtimeout >/dev/null 2>&1; then
+		echo "gtimeout"
+		return 0
+	fi
+
+	echo ""
+}
+
+is_provider_qualified_model() {
+	case "$1" in
+	vertex_ai/* | vertex_ai_beta/* | openai/* | anthropic/* | azure/* | gemini/* | bedrock/* | groq/* | mistral/* | cohere/* | ollama/* | huggingface/* | xai/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+is_vertex_resource_path() {
+	case "$1" in
+	projects/*/locations/*/publishers/*/models/* | */models/* | models/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+extract_vertex_model_id() {
+	local raw_model="$1"
+	local model_id="$raw_model"
+
+	if [[ "$model_id" == projects/*/locations/*/publishers/*/models/* ]]; then
+		model_id="${model_id##*/models/}"
+		echo "$model_id"
+		return 0
+	fi
+
+	if [[ "$model_id" == */models/* ]]; then
+		model_id="${model_id##*/models/}"
+		echo "$model_id"
+		return 0
+	fi
+
+	if [[ "$model_id" == models/* ]]; then
+		echo "${model_id#models/}"
+		return 0
+	fi
+
+	echo "$model_id"
+}
+
+normalize_model() {
+	local raw_model="$1"
+	raw_model="$(trim_whitespace "$raw_model")"
+	if [ -z "$raw_model" ]; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	if is_provider_qualified_model "$raw_model"; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	if [[ "$raw_model" == */* ]] && ! is_vertex_resource_path "$raw_model"; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	if is_vertex_resource_path "$raw_model"; then
+		local vertex_provider="${DEFAULT_PROVIDER%/}"
+		if [ "$vertex_provider" != "vertex_ai" ] && [ "$vertex_provider" != "vertex_ai_beta" ]; then
+			vertex_provider="vertex_ai"
+		fi
+
+		echo "$vertex_provider/$(extract_vertex_model_id "$raw_model")"
+		return 0
+	fi
+
+	if [ -z "$DEFAULT_PROVIDER" ]; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	local normalized_model="$raw_model"
+	local provider="${DEFAULT_PROVIDER%/}"
+	if [ "$provider" = "vertex_ai" ] || [ "$provider" = "vertex_ai_beta" ]; then
+		normalized_model="$(extract_vertex_model_id "$raw_model")"
+	fi
+
+	echo "$provider/$normalized_model"
+}
+
+PRIMARY_MODEL="$(normalize_model "$STRIX_LLM")"
+if [ "$PRIMARY_MODEL" != "$STRIX_LLM" ]; then
+	echo "Normalized STRIX_LLM to provider-qualified model '$PRIMARY_MODEL'."
+fi
+
+require_positive_integer "$STRIX_ATTEMPT_TIMEOUT_SECONDS" "STRIX_ATTEMPT_TIMEOUT_SECONDS"
+require_positive_integer "$STRIX_ATTEMPT_KILL_AFTER_SECONDS" "STRIX_ATTEMPT_KILL_AFTER_SECONDS"
+require_non_negative_integer "$STRIX_TRANSIENT_RETRY_PER_MODEL" "STRIX_TRANSIENT_RETRY_PER_MODEL"
+require_non_negative_integer "$STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS" "STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS"
+
+if [ "$(severity_rank "$STRIX_FAIL_ON_MIN_SEVERITY")" -lt 0 ]; then
+	echo "ERROR: STRIX_FAIL_ON_MIN_SEVERITY must be one of CRITICAL/HIGH/MEDIUM/LOW/INFO/INFORMATIONAL/NONE, got '$STRIX_FAIL_ON_MIN_SEVERITY'." >&2
+	exit 2
+fi
+
+capture_preexisting_report_dirs
+TIMEOUT_BIN="$(resolve_timeout_bin)"
+
+is_vertex_model() {
+	case "$1" in
+	vertex_ai/* | vertex_ai_beta/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+prepare_llm_api_base() {
+	local model="$1"
+
+	if is_vertex_model "$model"; then
+		unset LLM_API_BASE
+		return 0
+	fi
+
+	local llm_api_base_value="${RAW_LLM_API_BASE:-$ORIGINAL_LLM_API_BASE}"
+	llm_api_base_value="${llm_api_base_value%%/generateContent*}"
+	llm_api_base_value="${llm_api_base_value%%:generateContent*}"
+	if [ -n "$llm_api_base_value" ]; then
+		export LLM_API_BASE="$llm_api_base_value"
+	else
+		unset LLM_API_BASE
+	fi
+}
+
+run_strix_once() {
+	local model="$1"
+	local rc
+	export STRIX_LLM="$model"
+	export LLM_MODEL="$model"
+	prepare_llm_api_base "$model"
+	set -o pipefail
+	set +e
+	if [ -n "$TIMEOUT_BIN" ]; then
+		"$TIMEOUT_BIN" --signal=TERM --kill-after="${STRIX_ATTEMPT_KILL_AFTER_SECONDS}s" "${STRIX_ATTEMPT_TIMEOUT_SECONDS}s" \
+			strix -n -t "$TARGET_PATH" --scan-mode "$SCAN_MODE" 2>&1 | tee "$STRIX_LOG"
+		rc=$?
+	else
+		strix -n -t "$TARGET_PATH" --scan-mode "$SCAN_MODE" 2>&1 | tee "$STRIX_LOG"
+		rc=$?
+	fi
+	set -e
+
+	if [ "$rc" -eq 0 ]; then
+		return 0
+	fi
+
+	if [ -n "$TIMEOUT_BIN" ] && { [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; }; then
+		printf "Strix run timed out for model '%s' after %ss.\n" "$model" "$STRIX_ATTEMPT_TIMEOUT_SECONDS" | tee -a "$STRIX_LOG" >&2
+	fi
+
+	return 1
+}
+
+is_transient_same_model_retry_error() {
+	if is_rate_limit_error; then
+		return 0
+	fi
+
+	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	return 1
+}
+
+run_strix_with_transient_retry() {
+	local model="$1"
+	local max_attempts=$((STRIX_TRANSIENT_RETRY_PER_MODEL + 1))
+	local attempt=1
+
+	while [ "$attempt" -le "$max_attempts" ]; do
+		if run_strix_once "$model"; then
+			return 0
+		fi
+
+		if [ "$attempt" -ge "$max_attempts" ]; then
+			return 1
+		fi
+
+		if ! is_transient_same_model_retry_error; then
+			return 1
+		fi
+
+		echo "Retrying model '$model' due to transient LLM failure (attempt $((attempt + 1))/$max_attempts)." >&2
+		sleep "$STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS"
+		attempt=$((attempt + 1))
+	done
+
+	return 1
+}
+
+is_vertex_not_found_error() {
+	if grep -Fq 'litellm.NotFoundError: Vertex_aiException' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Eq '"status"[[:space:]]*:[[:space:]]*"NOT_FOUND"' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Fq 'Publisher Model ' "$STRIX_LOG" && grep -Fq ' was not found' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+is_rate_limit_error() {
+	if grep -Fq 'RateLimitError' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Eq '"status"[[:space:]]*:[[:space:]]*"RESOURCE_EXHAUSTED"' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Eq '(^|[^0-9])429([^0-9]|$)' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+is_timeout_error() {
+	if grep -Fq 'Strix run timed out for model ' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Fq 'litellm.exceptions.Timeout' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Fq 'httpx.ReadTimeout' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Fq 'httpcore.ReadTimeout' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Fq 'Connection timed out' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+is_midstream_fallback_error() {
+	if grep -Fq 'MidStreamFallbackError' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+latest_strix_report_dir() {
+	local latest=""
+	local run_dir
+
+	for run_dir in "$STRIX_REPORTS_DIR"/*; do
+		if [ ! -d "$run_dir" ] || [ -L "$run_dir" ]; then
+			continue
+		fi
+
+		if is_preexisting_report_dir "$run_dir"; then
+			continue
+		fi
+
+		if [ -z "$latest" ] || [ "$run_dir" -nt "$latest" ]; then
+			latest="$run_dir"
+		fi
+	done
+
+	if [ -z "$latest" ]; then
+		return 1
+	fi
+
+	echo "$latest"
+}
+
+has_only_below_threshold_vulnerabilities() {
+	local latest_report_dir
+	if ! latest_report_dir="$(latest_strix_report_dir)"; then
+		return 1
+	fi
+
+	local threshold_rank
+	threshold_rank="$(severity_rank "$STRIX_FAIL_ON_MIN_SEVERITY")"
+
+	local vulnerabilities_dir="$latest_report_dir/vulnerabilities"
+	if [ ! -d "$vulnerabilities_dir" ] || [ -L "$vulnerabilities_dir" ]; then
+		return 1
+	fi
+
+	local saw_severity=0
+	local max_rank=-1
+	local vuln_file
+	local line
+	local severity
+	local rank
+
+	for vuln_file in "$vulnerabilities_dir"/*.md; do
+		if [ ! -f "$vuln_file" ] || [ -L "$vuln_file" ]; then
+			continue
+		fi
+
+		while IFS= read -r line; do
+			if [[ "${line^^}" =~ SEVERITY[[:space:]]*:[[:space:][:punct:]]*(CRITICAL|HIGH|MEDIUM|LOW|INFO|INFORMATIONAL|NONE)([[:space:][:punct:]]|$) ]]; then
+				severity="${BASH_REMATCH[1]}"
+			else
+				continue
+			fi
+
+			rank="$(severity_rank "$severity")"
+			if [ "$rank" -lt 0 ]; then
+				continue
+			fi
+
+			saw_severity=1
+			if [ "$rank" -gt "$max_rank" ]; then
+				max_rank="$rank"
+			fi
+		done < <(grep -Ei 'severity[[:space:]]*:' "$vuln_file" || true)
+	done
+
+	if [ "$saw_severity" -eq 0 ]; then
+		return 1
+	fi
+
+	if [ "$max_rank" -lt "$threshold_rank" ]; then
+		echo "Strix findings are below configured fail threshold '$STRIX_FAIL_ON_MIN_SEVERITY'; allowing pipeline continuation." >&2
+		return 0
+	fi
+
+	return 1
+}
+
+is_hallucinated_endpoint_finding() {
+	local source_dir="${TARGET_PATH%/}/src"
+	if [ ! -d "$source_dir" ]; then
+		return 1
+	fi
+
+	local latest_report_dir
+	if ! latest_report_dir="$(latest_strix_report_dir)"; then
+		return 1
+	fi
+
+	local endpoint_seen=0
+	local endpoint_present_in_source=0
+	local endpoint
+	local vuln_file
+
+	for vuln_file in "$latest_report_dir"/vulnerabilities/*.md; do
+		if [ ! -f "$vuln_file" ]; then
+			continue
+		fi
+
+		while IFS= read -r endpoint; do
+			if [ -z "$endpoint" ]; then
+				continue
+			fi
+
+			endpoint_seen=1
+			if grep -R -Fq -- "$endpoint" "$source_dir"; then
+				endpoint_present_in_source=1
+				break
+			fi
+		done < <(grep -Eo '/api/[[:alnum:]_./-]+' "$vuln_file" | sort -u)
+
+		if [ "$endpoint_present_in_source" -eq 1 ]; then
+			break
+		fi
+	done
+
+	if [ "$endpoint_seen" -eq 0 ]; then
+		return 1
+	fi
+
+	if [ "$endpoint_present_in_source" -eq 1 ]; then
+		return 1
+	fi
+
+	echo "Detected Strix report endpoint(s) absent from source; treating as retryable model inconsistency." >&2
+	return 0
+}
+
+is_vertex_retryable_error() {
+	if is_vertex_not_found_error; then
+		return 0
+	fi
+
+	if is_rate_limit_error; then
+		return 0
+	fi
+
+	if is_timeout_error; then
+		return 0
+	fi
+
+	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	if is_hallucinated_endpoint_finding; then
+		return 0
+	fi
+
+	return 1
+}
+
+if run_strix_with_transient_retry "$PRIMARY_MODEL"; then
+	exit 0
+fi
+
+if has_only_below_threshold_vulnerabilities; then
+	exit 0
+fi
+
+if ! is_vertex_model "$PRIMARY_MODEL"; then
+	echo "Strix quick scan failed with a non-recoverable error." >&2
+	exit 1
+fi
+
+if ! is_vertex_retryable_error; then
+	echo "Strix quick scan failed with a non-recoverable error." >&2
+	exit 1
+fi
+
+FALLBACK_MODELS_RAW="${STRIX_VERTEX_FALLBACK_MODELS:-vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash}"
+FALLBACK_MODELS_RAW="${FALLBACK_MODELS_RAW//$'\r'/ }"
+FALLBACK_MODELS_RAW="${FALLBACK_MODELS_RAW//$'\n'/ }"
+read -r -a FALLBACK_MODELS <<<"$FALLBACK_MODELS_RAW"
+
+for candidate_raw in "${FALLBACK_MODELS[@]}"; do
+	candidate="$(normalize_model "$candidate_raw")"
+	if [ -z "$candidate" ] || [ "$candidate" = "$PRIMARY_MODEL" ]; then
+		continue
+	fi
+
+	echo "Primary Vertex model unavailable; retrying with fallback '$candidate'."
+	if run_strix_with_transient_retry "$candidate"; then
+		echo "Strix quick scan succeeded with fallback model '$candidate'."
+		exit 0
+	fi
+
+	if has_only_below_threshold_vulnerabilities; then
+		exit 0
+	fi
+
+	if ! is_vertex_retryable_error; then
+		echo "Strix quick scan failed with a non-recoverable error." >&2
+		exit 1
+	fi
+done
+
+echo "Configured Vertex model and fallback models were unavailable." >&2
+exit 1

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1,0 +1,958 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/../.." && pwd -P)"
+GATE_SCRIPT="$REPO_ROOT/scripts/ci/strix_quick_gate.sh"
+
+FAILURES=0
+
+record_failure() {
+	echo "FAIL: $1" >&2
+	FAILURES=$((FAILURES + 1))
+}
+
+assert_equals() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		record_failure "$message (expected='$expected' actual='$actual')"
+	fi
+}
+
+assert_file_contains() {
+	local file_path="$1"
+	local needle="$2"
+	local message="$3"
+
+	if ! grep -Fq -- "$needle" "$file_path"; then
+		record_failure "$message (missing '$needle')"
+	fi
+}
+
+run_gate_case() {
+	local scenario="$1"
+	local initial_model="$2"
+	local fallback_models="$3"
+	local expected_exit="$4"
+	local expected_message="$5"
+	local expected_calls="$6"
+	local expected_model_sequence="${7:-}"
+	local expected_api_base_sequence="${8:-}"
+	local default_provider="${9-vertex_ai}"
+	local raw_llm_api_base_override="${10-__DEFAULT__}"
+	local initial_llm_api_base="${11-}"
+
+	local raw_llm_api_base="https://example.invalid/generateContent"
+	if [ "$raw_llm_api_base_override" != "__DEFAULT__" ]; then
+		raw_llm_api_base="$raw_llm_api_base_override"
+	fi
+	local attempt_timeout_seconds="${12-}"
+	local fake_hang_seconds="${13-2}"
+	local transient_retry_per_model="${14-0}"
+	local min_fail_severity="${15-CRITICAL}"
+
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	# Create src/ so is_hallucinated_endpoint_finding() has a directory to scan,
+	# making the test self-contained regardless of the repo's actual layout.
+	mkdir -p "$tmp_dir/src"
+	local fake_strix="$tmp_dir/strix"
+	local call_log="$tmp_dir/calls.log"
+	local api_base_log="$tmp_dir/api_base.log"
+	local state_file="$tmp_dir/state.log"
+	local output_log="$tmp_dir/output.log"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "${STRIX_LLM:-}" >> "${FAKE_STRIX_CALL_LOG:?}"
+echo "${LLM_API_BASE:-<unset>}" >> "${FAKE_STRIX_API_BASE_LOG:?}"
+
+STRIX_REPORTS_DIR="${STRIX_REPORTS_DIR:-strix_runs}"
+
+case "${FAKE_STRIX_SCENARIO:?}" in
+	success)
+		echo "scan ok"
+		exit 0
+		;;
+	vertex-primary-notfound-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok with fallback"
+			exit 0
+			;;
+		*)
+			echo "unexpected model ${STRIX_LLM:-}" >&2
+			exit 9
+			;;
+		esac
+		;;
+	vertex-all-notfound)
+		echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+		echo '"status": "NOT_FOUND"'
+		exit 1
+		;;
+	nonrecoverable)
+		echo "Error: transport timeout"
+		exit 1
+		;;
+	provider-prefix-required)
+		if [ "${STRIX_LLM:-}" = "vertex_ai/gemini-2.5-pro" ]; then
+			echo "scan ok with normalized provider"
+			exit 0
+		fi
+		echo "Error: provider prefix not normalized (${STRIX_LLM:-})" >&2
+		exit 10
+		;;
+	provider-prefix-fallback-normalization)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after fallback normalization"
+			exit 0
+			;;
+		*)
+			echo "Error: fallback provider prefix not normalized (${STRIX_LLM:-})" >&2
+			exit 11
+			;;
+		esac
+		;;
+	provider-prefix-required-resource-path-primary-implicit-default-provider | provider-prefix-required-resource-path-primary-explicit-empty-default-provider)
+		if [ "${STRIX_LLM:-}" = "vertex_ai/gemini-2.5-pro" ]; then
+			echo "scan ok with resource-path normalization"
+			exit 0
+		fi
+		echo "Error: resource-path model not normalized (${STRIX_LLM:-})" >&2
+		exit 12
+		;;
+	provider-prefix-resource-path-primary-notfound-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after resource-path fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: resource-path fallback model not normalized (${STRIX_LLM:-})" >&2
+			exit 13
+			;;
+		esac
+		;;
+	vertex-notfound-without-status-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after status-less not found fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: status-less fallback model not normalized (${STRIX_LLM:-})" >&2
+			exit 14
+			;;
+		esac
+		;;
+	vertex-notfound-compact-status-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo '{"error":{"status":"NOT_FOUND"}}'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after compact-status not found fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: compact-status fallback model not normalized (${STRIX_LLM:-})" >&2
+			exit 17
+			;;
+		esac
+		;;
+	nonvertex-slash-model-passthrough)
+		if [ "${STRIX_LLM:-}" = "foo/bar" ]; then
+			echo "scan ok with non-vertex slash model passthrough"
+			exit 0
+		fi
+		echo "Error: non-vertex slash model was rewritten (${STRIX_LLM:-})" >&2
+		exit 18
+		;;
+	primary-duplicate-in-fallback)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after duplicate-primary skip"
+			exit 0
+			;;
+		*)
+			echo "Error: duplicate-primary path unexpected (${STRIX_LLM:-})" >&2
+			exit 15
+			;;
+		esac
+		;;
+	multiline-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-two)
+			echo "scan ok after multiline fallback parsing"
+			exit 0
+			;;
+		*)
+			echo "Error: multiline fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 19
+			;;
+		esac
+		;;
+	vertex-primary-ratelimit-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/ratelimit-primary)
+			echo "Penetration test failed: LLM request failed: RateLimitError"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after rate-limit fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: ratelimit fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 21
+			;;
+		esac
+		;;
+	vertex-primary-resource-exhausted-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/resource-exhausted-primary)
+			echo '{"error":{"status":"RESOURCE_EXHAUSTED"}}'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after resource exhausted fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: resource exhausted fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 23
+			;;
+		esac
+		;;
+	vertex-primary-429-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/http429-primary)
+			echo "HTTP 429 Too Many Requests"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after 429 fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: 429 fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 24
+			;;
+		esac
+		;;
+	vertex-primary-midstream-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/midstream-primary)
+			echo "Penetration test failed: LLM request failed: MidStreamFallbackError"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after midstream fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: midstream fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 25
+			;;
+		esac
+		;;
+	vertex-primary-midstream-retry-same-model-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/retry-midstream-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" > "${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "Penetration test failed: LLM request failed: MidStreamFallbackError"
+				exit 1
+			fi
+			echo "scan ok after same-model retry"
+			exit 0
+			;;
+		*)
+			echo "Error: same-model retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 30
+			;;
+		esac
+		;;
+	vertex-all-ratelimited)
+		echo "Penetration test failed: LLM request failed: RateLimitError"
+		exit 1
+		;;
+	vertex-primary-timeout-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/timeout-primary)
+			sleep "${FAKE_STRIX_HANG_SECONDS:-2}"
+			echo "litellm.exceptions.Timeout: litellm.Timeout: Connection timed out after None seconds."
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after timeout fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: timeout fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 22
+			;;
+		esac
+		;;
+	vertex-all-timeout)
+		sleep "${FAKE_STRIX_HANG_SECONDS:-2}"
+		echo "litellm.exceptions.Timeout: litellm.Timeout: Connection timed out after None seconds."
+		exit 1
+		;;
+	vertex-primary-hallucinated-endpoint-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/hallucination-primary)
+			mkdir -p "$STRIX_REPORTS_DIR/fake-hallucinated/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/fake-hallucinated/vulnerabilities/vuln-0001.md" <<'EOS'
+**Endpoint:** /api/ghost-admin
+EOS
+			echo "Penetration test failed: CRITICAL finding on /api/ghost-admin"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after hallucinated-endpoint fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: hallucinated-endpoint fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 26
+			;;
+		esac
+		;;
+	vertex-primary-existing-endpoint-nonrecoverable)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/existing-endpoint-primary)
+			mkdir -p "$STRIX_REPORTS_DIR/fake-existing-endpoint/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/fake-existing-endpoint/vulnerabilities/vuln-0001.md" <<'EOS'
+**Endpoint:** /api/status
+EOS
+			echo "Penetration test failed: CRITICAL finding on /api/status"
+			exit 1
+			;;
+		vertex_ai/fallback-one|vertex_ai/fallback-two)
+			echo "Error: existing endpoint findings must remain non-recoverable (${STRIX_LLM:-})" >&2
+			exit 27
+			;;
+		*)
+			echo "Error: existing-endpoint scenario unexpected model (${STRIX_LLM:-})" >&2
+			exit 28
+			;;
+		esac
+		;;
+	high-vuln-below-threshold)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-high/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-high/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: HIGH
+EOS
+		echo "Penetration test failed: simulated high finding"
+		exit 1
+		;;
+	critical-vuln-at-threshold)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-critical/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-critical/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: CRITICAL
+EOS
+		echo "Penetration test failed: simulated critical finding"
+		exit 1
+		;;
+	malformed-severity-marker-nonrecoverable)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-malformed/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-malformed/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity details: high confidence marker only
+EOS
+		echo "Penetration test failed: malformed severity marker"
+		exit 1
+		;;
+	preserve-existing-api-base)
+		if [ "${LLM_API_BASE:-}" = "https://preexisting.invalid" ]; then
+			echo "scan ok with preserved api base"
+			exit 0
+		fi
+		echo "Error: existing LLM_API_BASE was not preserved (${LLM_API_BASE:-<unset>})" >&2
+		exit 20
+		;;
+	default-fallback-order-fast-first)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/gemini-2.5-pro)
+			echo "scan ok with default fast fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: default fallback order unexpected (${STRIX_LLM:-})" >&2
+			exit 16
+			;;
+		esac
+		;;
+	*)
+		echo "unknown scenario ${FAKE_STRIX_SCENARIO:?}" >&2
+		exit 8
+		;;
+esac
+EOF
+	chmod +x "$fake_strix"
+
+	# Scenario-specific source-tree setup so is_hallucinated_endpoint_finding()
+	# can locate "real" endpoints inside the self-contained temp workspace.
+	if [ "$scenario" = "vertex-primary-existing-endpoint-nonrecoverable" ]; then
+		echo 'GET /api/status' >"$tmp_dir/src/routes.txt"
+	fi
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		FAKE_STRIX_SCENARIO="$scenario" \
+		FAKE_STRIX_CALL_LOG="$call_log" \
+		FAKE_STRIX_API_BASE_LOG="$api_base_log" \
+		STRIX_LLM="$initial_model" \
+		STRIX_LLM_DEFAULT_PROVIDER="$default_provider" \
+		LLM_API_KEY="dummy" \
+		RAW_LLM_API_BASE="$raw_llm_api_base" \
+		LLM_API_BASE="$initial_llm_api_base" \
+		STRIX_ATTEMPT_TIMEOUT_SECONDS="$attempt_timeout_seconds" \
+		FAKE_STRIX_HANG_SECONDS="$fake_hang_seconds" \
+		FAKE_STRIX_STATE_FILE="$state_file" \
+		STRIX_TRANSIENT_RETRY_PER_MODEL="$transient_retry_per_model" \
+		STRIX_FAIL_ON_MIN_SEVERITY="$min_fail_severity" \
+		STRIX_VERTEX_FALLBACK_MODELS="$fallback_models" \
+		STRIX_REPORTS_DIR="$tmp_dir/strix_runs" \
+		STRIX_TARGET_PATH="$tmp_dir" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "$expected_exit" "$rc" "scenario=$scenario exit code"
+
+	if [ -n "$expected_message" ]; then
+		assert_file_contains "$output_log" "$expected_message" "scenario=$scenario output"
+	fi
+
+	local call_count
+	call_count="0"
+	if [ -f "$call_log" ]; then
+		call_count="$(wc -l <"$call_log" | tr -d ' ')"
+	fi
+	assert_equals "$expected_calls" "$call_count" "scenario=$scenario strix call count"
+
+	if [ -n "$expected_model_sequence" ]; then
+		local actual_model_sequence=""
+		if [ -f "$call_log" ]; then
+			while IFS= read -r model; do
+				if [ -n "$actual_model_sequence" ]; then
+					actual_model_sequence="${actual_model_sequence}|$model"
+				else
+					actual_model_sequence="$model"
+				fi
+			done <"$call_log"
+		fi
+
+		assert_equals "$expected_model_sequence" "$actual_model_sequence" "scenario=$scenario STRIX_LLM sequence"
+	fi
+
+	if [ -n "$expected_api_base_sequence" ]; then
+		local actual_api_base_sequence=""
+		if [ -f "$api_base_log" ]; then
+			while IFS= read -r api_base; do
+				if [ -n "$actual_api_base_sequence" ]; then
+					actual_api_base_sequence="${actual_api_base_sequence}|$api_base"
+				else
+					actual_api_base_sequence="$api_base"
+				fi
+			done <"$api_base_log"
+		fi
+
+		assert_equals "$expected_api_base_sequence" "$actual_api_base_sequence" "scenario=$scenario LLM_API_BASE sequence"
+	fi
+
+	rm -rf "$tmp_dir"
+}
+
+run_missing_config_case() {
+	local case_name="$1"
+	local strix_llm="$2"
+	local llm_api_key="$3"
+	local expected_message="$4"
+
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local call_count_file="$tmp_dir/strix_calls"
+	local fake_strix="$tmp_dir/strix"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "1" >> "${STRIX_CALL_COUNT_FILE:?}"
+exit 0
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="$strix_llm" \
+		LLM_API_KEY="$llm_api_key" \
+		STRIX_CALL_COUNT_FILE="$call_count_file" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "2" "$rc" "case=$case_name exit code"
+	assert_file_contains "$output_log" "$expected_message" "case=$case_name output"
+
+	local actual_calls="0"
+	if [ -f "$call_count_file" ]; then
+		actual_calls="$(wc -l <"$call_count_file" | tr -d ' ')"
+	fi
+	assert_equals "0" "$actual_calls" "case=$case_name strix call count"
+
+	rm -rf "$tmp_dir"
+}
+
+run_invalid_min_fail_severity_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local fake_strix="$tmp_dir/strix"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "unexpected strix execution" >&2
+exit 99
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="vertex_ai/ready-primary" \
+		LLM_API_KEY="dummy" \
+		STRIX_FAIL_ON_MIN_SEVERITY="BOGUS" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "2" "$rc" "case=invalid-min-fail-severity exit code"
+	assert_file_contains "$output_log" "STRIX_FAIL_ON_MIN_SEVERITY must be one of CRITICAL/HIGH/MEDIUM/LOW/INFO/INFORMATIONAL" "case=invalid-min-fail-severity output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_stale_report_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local fake_strix="$tmp_dir/strix"
+	local stale_report_dir="$tmp_dir/strix_runs/stale/vulnerabilities"
+
+	mkdir -p "$stale_report_dir"
+	cat >"$stale_report_dir/vuln-0001.md" <<'EOF'
+Severity: LOW
+EOF
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Error: transport timeout"
+exit 1
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="openai/gpt-4o-mini" \
+		LLM_API_KEY="dummy" \
+		RAW_LLM_API_BASE="https://example.invalid/generateContent" \
+		STRIX_REPORTS_DIR="$tmp_dir/strix_runs" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "1" "$rc" "case=stale-report-does-not-bypass exit code"
+	assert_file_contains "$output_log" "Strix quick scan failed with a non-recoverable error." "case=stale-report-does-not-bypass output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_symlink_report_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local fake_strix="$tmp_dir/strix"
+	local external_report_dir="$tmp_dir/external/vulnerabilities"
+
+	mkdir -p "$external_report_dir" "$tmp_dir/strix_runs"
+	cat >"$external_report_dir/vuln-0001.md" <<'EOF'
+Severity: LOW
+EOF
+	ln -s "$tmp_dir/external" "$tmp_dir/strix_runs/latest"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Error: transport timeout"
+exit 1
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="openai/gpt-4o-mini" \
+		LLM_API_KEY="dummy" \
+		RAW_LLM_API_BASE="https://example.invalid/generateContent" \
+		STRIX_REPORTS_DIR="$tmp_dir/strix_runs" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "1" "$rc" "case=symlink-report-does-not-bypass exit code"
+	assert_file_contains "$output_log" "Strix quick scan failed with a non-recoverable error." "case=symlink-report-does-not-bypass output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_gate_case "success" \
+	"vertex_ai/ready-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok" \
+	"1" \
+	"vertex_ai/ready-primary" \
+	"<unset>"
+
+run_gate_case "vertex-primary-notfound-fallback-success" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-all-notfound" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Configured Vertex model and fallback models were unavailable." \
+	"3" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "nonrecoverable" \
+	"openai/gpt-4o-mini" \
+	"vertex_ai/fallback-one" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://example.invalid"
+
+run_gate_case "provider-prefix-required" \
+	"gemini-2.5-pro" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/gemini-2.5-pro'." \
+	"1" \
+	"vertex_ai/gemini-2.5-pro" \
+	"<unset>"
+
+run_gate_case "provider-prefix-fallback-normalization" \
+	"missing-primary" \
+	"fallback-one fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "provider-prefix-required-resource-path-primary-implicit-default-provider" \
+	"projects/p1/locations/us-central1/publishers/google/models/gemini-2.5-pro" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/gemini-2.5-pro'." \
+	"1" \
+	"vertex_ai/gemini-2.5-pro" \
+	"<unset>"
+
+run_gate_case "provider-prefix-required-resource-path-primary-explicit-empty-default-provider" \
+	"projects/p1/locations/us-central1/publishers/google/models/gemini-2.5-pro" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/gemini-2.5-pro'." \
+	"1" \
+	"vertex_ai/gemini-2.5-pro" \
+	"<unset>" \
+	""
+
+run_gate_case "provider-prefix-resource-path-primary-notfound-fallback-success" \
+	"projects/p1/locations/us-central1/publishers/google/models/missing-primary" \
+	"projects/p1/locations/us-central1/publishers/google/models/fallback-one projects/p1/locations/us-central1/publishers/google/models/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-notfound-without-status-fallback-success" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-notfound-compact-status-fallback-success" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "nonvertex-slash-model-passthrough" \
+	"foo/bar" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"scan ok with non-vertex slash model passthrough" \
+	"1" \
+	"foo/bar" \
+	"https://example.invalid"
+
+run_gate_case "primary-duplicate-in-fallback" \
+	"missing-primary" \
+	"vertex_ai/missing-primary fallback-one" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "multiline-fallback-success" \
+	"vertex_ai/missing-primary" \
+	$'vertex_ai/fallback-one\nvertex_ai/fallback-two' \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-two'." \
+	"3" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "vertex-primary-ratelimit-fallback-success" \
+	"vertex_ai/ratelimit-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/ratelimit-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-resource-exhausted-fallback-success" \
+	"vertex_ai/resource-exhausted-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/resource-exhausted-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-429-fallback-success" \
+	"vertex_ai/http429-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/http429-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-midstream-fallback-success" \
+	"vertex_ai/midstream-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/midstream-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-midstream-retry-same-model-success" \
+	"vertex_ai/retry-midstream-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model retry" \
+	"2" \
+	"vertex_ai/retry-midstream-primary|vertex_ai/retry-midstream-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"" \
+	"2" \
+	"1"
+
+run_gate_case "vertex-all-ratelimited" \
+	"vertex_ai/ratelimit-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Configured Vertex model and fallback models were unavailable." \
+	"3" \
+	"vertex_ai/ratelimit-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "vertex-primary-timeout-fallback-success" \
+	"vertex_ai/timeout-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix run timed out for model 'vertex_ai/timeout-primary' after 1s." \
+	"2" \
+	"vertex_ai/timeout-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1" \
+	"2"
+
+run_gate_case "vertex-all-timeout" \
+	"vertex_ai/timeout-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Configured Vertex model and fallback models were unavailable." \
+	"3" \
+	"vertex_ai/timeout-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1" \
+	"2"
+
+run_gate_case "vertex-primary-hallucinated-endpoint-fallback-success" \
+	"vertex_ai/hallucination-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/hallucination-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-existing-endpoint-nonrecoverable" \
+	"vertex_ai/existing-endpoint-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/existing-endpoint-primary" \
+	"<unset>"
+
+run_gate_case "high-vuln-below-threshold" \
+	"vertex_ai/high-vuln-primary" \
+	"" \
+	"0" \
+	"below configured fail threshold 'CRITICAL'" \
+	"1" \
+	"vertex_ai/high-vuln-primary" \
+	"<unset>"
+
+run_gate_case "critical-vuln-at-threshold" \
+	"vertex_ai/critical-vuln-primary" \
+	"" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/critical-vuln-primary" \
+	"<unset>"
+
+run_gate_case "malformed-severity-marker-nonrecoverable" \
+	"vertex_ai/malformed-severity-primary" \
+	"" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/malformed-severity-primary" \
+	"<unset>"
+
+run_gate_case "preserve-existing-api-base" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"0" \
+	"scan ok with preserved api base" \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://preexisting.invalid" \
+	"vertex_ai" \
+	"" \
+	"https://preexisting.invalid"
+
+run_gate_case "default-fallback-order-fast-first" \
+	"vertex_ai/missing-primary" \
+	"" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/gemini-2.5-pro'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/gemini-2.5-pro" \
+	"<unset>|<unset>"
+
+run_invalid_min_fail_severity_case
+run_stale_report_case
+run_symlink_report_case
+
+run_missing_config_case "missing-strix-llm" "" "dummy" "ERROR: STRIX_LLM is required."
+run_missing_config_case "missing-llm-api-key" "vertex_ai/ready-primary" "" "ERROR: LLM_API_KEY is required."
+run_missing_config_case "whitespace-only-strix-llm" "   " "dummy" "ERROR: STRIX_LLM is required."
+run_missing_config_case "whitespace-only-llm-api-key" "vertex_ai/ready-primary" $'\t  ' "ERROR: LLM_API_KEY is required."
+
+if [ "$FAILURES" -ne 0 ]; then
+	echo "test_strix_quick_gate: ${FAILURES} failure(s)" >&2
+	exit 1
+fi
+
+echo "test_strix_quick_gate: PASS"


### PR DESCRIPTION
## Summary

- Add standardized `strix.yml` workflow from `dns-guard`
- Add `scripts/ci/strix_quick_gate.sh` — main gate script with Vertex AI fallback, retry logic, severity thresholds
- Add `scripts/ci/test_strix_quick_gate.sh` — comprehensive test suite for the gate script

## Changes

| File | Action |
|---|---|
| `.github/workflows/strix.yml` | Added (standardized workflow, `STRIX_TARGET_PATH: ./`) |
| `scripts/ci/strix_quick_gate.sh` | Added |
| `scripts/ci/test_strix_quick_gate.sh` | Added |

## Context

This is part of an org-wide effort to standardize the Strix security scan pipeline across all repositories in `HYOSUNG-ITX-AI-Business-Department`, using `dns-guard` as the source of truth.