### PR TITLE
ci(strix): sync pipeline with dns-guard canonical (timeout removal + hardening)

### DIFF
--- a/.github/workflows/strix.yml
+++ b/.github/workflows/strix.yml
@@ -1,0 +1,127 @@
+name: Strix Security Scan
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+  schedule:
+    # Nightly scan on protected branches.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: strix-${{ github.workflow }}-${{ github.ref }}
+  # cancel-in-progress deliberately disabled: an attacker could force-push
+  # a benign commit to cancel an in-progress scan of a malicious commit.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  strix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Self-test Strix gate script
+        run: bash ./scripts/ci/test_strix_quick_gate.sh
+
+      - name: Gate Strix secrets
+        id: gate
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          strix_llm="$(printf '%s' "$STRIX_LLM" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          llm_api_key="$(printf '%s' "$LLM_API_KEY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          if [ -z "$strix_llm" ] || [ -z "$llm_api_key" ]; then
+            # On push/schedule to protected branches, fail-closed: missing
+            # secrets must not silently produce a green check.
+            if [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "schedule" ]; then
+              echo '::error::Strix secrets not configured on push/schedule event; failing closed.'
+              exit 1
+            fi
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+            echo 'Strix secrets not configured; skipping.'
+          else
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate GCP credentials
+        id: gcp_gate
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          if [ -n "$GCP_SA_KEY" ]; then
+            echo 'has_gcp=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_gcp=false' >> "$GITHUB_OUTPUT"
+            echo 'GCP credentials not configured; Vertex AI auth will not be available.'
+          fi
+
+      - name: Authenticate to Google Cloud
+        if: steps.gate.outputs.enabled == 'true' && steps.gcp_gate.outputs.has_gcp == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install Strix
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --no-cache-dir "strix-agent==0.8.3" "google-cloud-aiplatform>=1.133.0,<2"
+
+      - name: Mask LLM API key
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          # Sanitize CR/LF before masking to prevent broken ::add-mask::
+          # commands and potential workflow command injection.
+          sanitized="$(printf '%s' "$LLM_API_KEY" | tr -d '\r\n')"
+          if [ -n "$sanitized" ]; then
+            echo "::add-mask::${sanitized}"
+            trimmed="$(printf '%s' "$sanitized" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+            if [ -n "$trimmed" ] && [ "$trimmed" != "$sanitized" ]; then
+              echo "::add-mask::${trimmed}"
+            fi
+          fi
+
+      - name: Run Strix (quick)
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          STRIX_LLM_DEFAULT_PROVIDER: vertex_ai
+          VERTEX_LOCATION: global
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          RAW_LLM_API_BASE: ${{ secrets.LLM_API_BASE }}
+          STRIX_VERTEX_FALLBACK_MODELS: "vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash"
+          STRIX_TARGET_PATH: ./
+          STRIX_REASONING_EFFORT: ${{ github.event_name == 'push' && 'low' || 'minimal' }}
+          STRIX_LLM_MAX_RETRIES: 1
+          LLM_TIMEOUT: 90
+          STRIX_MEMORY_COMPRESSOR_TIMEOUT: 10
+          STRIX_TRANSIENT_RETRY_PER_MODEL: 2
+          STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS: 3
+          STRIX_FAIL_ON_MIN_SEVERITY: CRITICAL
+        run: bash ./scripts/ci/strix_quick_gate.sh
+
+      - name: Upload Strix reports artifact
+        if: ${{ always() && !cancelled() && steps.gate.outputs.enabled == 'true' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: strix-reports
+          path: strix_runs/
+          if-no-files-found: warn
+          retention-days: 5

--- a/scripts/ci/strix_quick_gate.sh
+++ b/scripts/ci/strix_quick_gate.sh
@@ -1,0 +1,871 @@
+#!/usr/bin/env bash
+# strix_quick_gate.sh — CI gate that runs Strix security scans with
+# automatic model fallback, transient-error retry, and severity-based
+# pass/fail decisions.
+#
+# STRIX_LOG is a per-attempt temp file consumed only by
+# is_transient_same_model_retry_error(); cumulative report dirs in
+# STRIX_REPORTS_DIR are never overwritten.  Refer to ARCHITECTURE.md
+# for the 3-tier timeout classification hierarchy.
+set -euo pipefail
+
+TARGET_PATH="${STRIX_TARGET_PATH:-./}"
+SCAN_MODE="${STRIX_SCAN_MODE:-quick}"
+STRIX_LOG="$(mktemp)"
+STRIX_REPORTS_DIR="${STRIX_REPORTS_DIR:-strix_runs}"
+DEFAULT_PROVIDER="${STRIX_LLM_DEFAULT_PROVIDER:-}"
+ORIGINAL_LLM_API_BASE="${LLM_API_BASE:-}"
+STRIX_TRANSIENT_RETRY_PER_MODEL="${STRIX_TRANSIENT_RETRY_PER_MODEL:-0}"
+STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS="${STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS:-3}"
+STRIX_FAIL_ON_MIN_SEVERITY="${STRIX_FAIL_ON_MIN_SEVERITY:-CRITICAL}"
+PREEXISTING_REPORT_DIRS=()
+# Sticky flag: once ANY attempt encounters an infrastructure error (rate limit,
+# LLM connection failure, mid-stream fallback, etc.), this flag stays 1 for
+# the rest of the run.  It prevents the "all findings below threshold" bypass
+# from masking scan incompleteness — a successful strix run (exit 0) ignores
+# this flag because the scan itself produced a complete result set.
+INFRA_ERROR_DETECTED=0
+
+cleanup() {
+	rm -f "$STRIX_LOG"
+}
+trap cleanup EXIT INT TERM
+
+trim_whitespace() {
+	local value="$1"
+	value="${value#"${value%%[![:space:]]*}"}"
+	value="${value%"${value##*[![:space:]]}"}"
+	echo "$value"
+}
+
+STRIX_LLM="$(trim_whitespace "${STRIX_LLM:-}")"
+if [ -z "$STRIX_LLM" ]; then
+	echo "ERROR: STRIX_LLM is required." >&2
+	exit 2
+fi
+
+LLM_API_KEY="$(trim_whitespace "${LLM_API_KEY:-}")"
+if [ -z "$LLM_API_KEY" ]; then
+	echo "ERROR: LLM_API_KEY is required." >&2
+	exit 2
+fi
+export STRIX_LLM
+export LLM_API_KEY
+
+require_non_negative_integer() {
+	local value="$1"
+	local label="$2"
+	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+		echo "ERROR: $label must be a non-negative integer, got '$value'." >&2
+		exit 2
+	fi
+}
+
+severity_rank() {
+	case "${1^^}" in
+	CRITICAL)
+		echo 4
+		;;
+	HIGH)
+		echo 3
+		;;
+	MEDIUM)
+		echo 2
+		;;
+	LOW)
+		echo 1
+		;;
+	INFO | INFORMATIONAL | NONE)
+		echo 0
+		;;
+	*)
+		echo -1
+		;;
+	esac
+}
+
+capture_preexisting_report_dirs() {
+	local run_dir
+	for run_dir in "$STRIX_REPORTS_DIR"/*; do
+		if [ ! -d "$run_dir" ]; then
+			continue
+		fi
+		PREEXISTING_REPORT_DIRS+=("$run_dir")
+	done
+}
+
+is_preexisting_report_dir() {
+	local candidate="$1"
+	local existing
+
+	for existing in "${PREEXISTING_REPORT_DIRS[@]}"; do
+		if [ "$candidate" = "$existing" ]; then
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+is_provider_qualified_model() {
+	case "$1" in
+	vertex_ai/* | vertex_ai_beta/* | openai/* | anthropic/* | azure/* | gemini/* | bedrock/* | groq/* | mistral/* | cohere/* | ollama/* | huggingface/* | xai/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+is_vertex_resource_path() {
+	# Validate Vertex AI resource path formats with strict segment-boundary
+	# enforcement.  We split on '/' using `read -ra` (shellcheck-safe) to
+	# reject malformed paths like "projects/a/b/locations/…".
+	local path="$1"
+	# Reject empty or whitespace-containing paths early.
+	[[ -z "$path" || "$path" =~ [[:space:]] ]] && return 1
+	local -a parts
+	IFS='/' read -ra parts <<<"$path"
+
+	local n=${#parts[@]}
+	case "$n" in
+	2) # models/<id>
+		[[ "${parts[0]}" == "models" && -n "${parts[1]}" ]]
+		return $?
+		;;
+	4) # publishers/<p>/models/<id>
+		[[ "${parts[0]}" == "publishers" && -n "${parts[1]}" && "${parts[2]}" == "models" && -n "${parts[3]}" ]]
+		return $?
+		;;
+	6) # projects/<p>/locations/<l>/models/<id>
+		[[ "${parts[0]}" == "projects" && -n "${parts[1]}" && "${parts[2]}" == "locations" && -n "${parts[3]}" && "${parts[4]}" == "models" && -n "${parts[5]}" ]]
+		return $?
+		;;
+	8) # projects/<p>/locations/<l>/publishers/<pub>/models/<id>
+		[[ "${parts[0]}" == "projects" && -n "${parts[1]}" && "${parts[2]}" == "locations" && -n "${parts[3]}" && "${parts[4]}" == "publishers" && -n "${parts[5]}" && "${parts[6]}" == "models" && -n "${parts[7]}" ]]
+		return $?
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+extract_vertex_model_id() {
+	local raw_model="$1"
+	# Whitespace inputs are not valid Vertex resource paths; pass through as-is.
+	[[ "$raw_model" =~ [[:space:]] ]] && {
+		echo "$raw_model"
+		return 0
+	}
+	local -a parts
+	IFS='/' read -ra parts <<<"$raw_model"
+
+	local n=${#parts[@]}
+	case "$n" in
+	8) # projects/<p>/locations/<l>/publishers/<pub>/models/<id>
+		if [[ "${parts[0]}" == "projects" && "${parts[2]}" == "locations" && "${parts[4]}" == "publishers" && "${parts[6]}" == "models" ]]; then
+			echo "${parts[7]}"
+			return 0
+		fi
+		;;
+	6) # projects/<p>/locations/<l>/models/<id>
+		if [[ "${parts[0]}" == "projects" && "${parts[2]}" == "locations" && "${parts[4]}" == "models" ]]; then
+			echo "${parts[5]}"
+			return 0
+		fi
+		;;
+	4) # publishers/<pub>/models/<id>
+		if [[ "${parts[0]}" == "publishers" && "${parts[2]}" == "models" ]]; then
+			echo "${parts[3]}"
+			return 0
+		fi
+		;;
+	2) # models/<id>
+		if [[ "${parts[0]}" == "models" ]]; then
+			echo "${parts[1]}"
+			return 0
+		fi
+		;;
+	esac
+
+	# Fallback: not a recognized Vertex resource path; return as-is
+	echo "$raw_model"
+}
+
+normalize_model() {
+	local raw_model="$1"
+	raw_model="$(trim_whitespace "$raw_model")"
+	if [ -z "$raw_model" ]; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	if is_provider_qualified_model "$raw_model"; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	if [[ "$raw_model" == */* ]] && ! is_vertex_resource_path "$raw_model"; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	if is_vertex_resource_path "$raw_model"; then
+		local vertex_provider="${DEFAULT_PROVIDER%/}"
+		if [ "$vertex_provider" != "vertex_ai" ] && [ "$vertex_provider" != "vertex_ai_beta" ]; then
+			vertex_provider="vertex_ai"
+		fi
+
+		echo "$vertex_provider/$(extract_vertex_model_id "$raw_model")"
+		return 0
+	fi
+
+	if [ -z "$DEFAULT_PROVIDER" ]; then
+		echo "$raw_model"
+		return 0
+	fi
+
+	local normalized_model="$raw_model"
+	local provider="${DEFAULT_PROVIDER%/}"
+	if [ "$provider" = "vertex_ai" ] || [ "$provider" = "vertex_ai_beta" ]; then
+		normalized_model="$(extract_vertex_model_id "$raw_model")"
+	fi
+
+	echo "$provider/$normalized_model"
+}
+
+PRIMARY_MODEL="$(normalize_model "$STRIX_LLM")"
+if [ "$PRIMARY_MODEL" != "$STRIX_LLM" ]; then
+	echo "Normalized STRIX_LLM to provider-qualified model '$PRIMARY_MODEL'."
+fi
+
+require_non_negative_integer "$STRIX_TRANSIENT_RETRY_PER_MODEL" "STRIX_TRANSIENT_RETRY_PER_MODEL"
+require_non_negative_integer "$STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS" "STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS"
+
+if [ "$(severity_rank "$STRIX_FAIL_ON_MIN_SEVERITY")" -lt 0 ]; then
+	echo "ERROR: STRIX_FAIL_ON_MIN_SEVERITY must be one of CRITICAL/HIGH/MEDIUM/LOW/INFO/INFORMATIONAL/NONE, got '$STRIX_FAIL_ON_MIN_SEVERITY'." >&2
+	exit 2
+fi
+
+capture_preexisting_report_dirs
+
+is_vertex_model() {
+	case "$1" in
+	vertex_ai/* | vertex_ai_beta/*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+prepare_llm_api_base() {
+	local model="$1"
+
+	if is_vertex_model "$model"; then
+		unset LLM_API_BASE
+		return 0
+	fi
+
+	local llm_api_base_value="${RAW_LLM_API_BASE:-$ORIGINAL_LLM_API_BASE}"
+	llm_api_base_value="${llm_api_base_value%%/generateContent*}"
+	llm_api_base_value="${llm_api_base_value%%:generateContent*}"
+	if [ -n "$llm_api_base_value" ]; then
+		export LLM_API_BASE="$llm_api_base_value"
+	else
+		unset LLM_API_BASE
+	fi
+}
+
+## Run a single strix invocation against TARGET_PATH with the given model.
+## Sets STRIX_LLM, LLM_MODEL, and prepares LLM_API_BASE before invocation.
+## Returns 0 on success (strix exit 0), 1 on any failure.
+## The caller is responsible for retry/fallback logic — this function is
+## intentionally fire-and-forget with no process-level timeout wrapping.
+run_strix_once() {
+	local model="$1"
+	local rc
+	export STRIX_LLM="$model"
+	export LLM_MODEL="$model"
+	prepare_llm_api_base "$model"
+	local start_epoch
+	start_epoch="$(date +%s)"
+	set -o pipefail
+	set +e
+	strix -n -t "$TARGET_PATH" --scan-mode "$SCAN_MODE" 2>&1 | tee "$STRIX_LOG"
+	rc=$?
+	set -e
+	local end_epoch
+	end_epoch="$(date +%s)"
+	local elapsed=$((end_epoch - start_epoch))
+
+	if [ "$rc" -eq 0 ]; then
+		printf "Strix run succeeded for model '%s' in %ds.\n" "$model" "$elapsed" >&2
+		return 0
+	fi
+
+	printf "Strix run failed for model '%s' after %ds (exit code %d).\n" "$model" "$elapsed" "$rc" >&2
+
+	# Sticky flag: record that at least one attempt hit an infrastructure
+	# error.  STRIX_LOG is overwritten per-attempt, so without this flag the
+	# below-threshold guard in has_only_below_threshold_vulnerabilities()
+	# would only see the *last* attempt's log — missing infrastructure errors
+	# from earlier attempts whose partial reports may still sit in the reports
+	# directory.
+	if has_detected_infrastructure_error; then
+		INFRA_ERROR_DETECTED=1
+	fi
+
+	return 1
+}
+
+## Determines whether the last strix failure is a transient error eligible
+## for same-model retry (up to STRIX_TRANSIENT_RETRY_PER_MODEL times).
+## Three error families qualify:
+##   - RateLimit / RESOURCE_EXHAUSTED / HTTP 429
+##   - MidStreamFallbackError (litellm mid-stream provider switch)
+##   - Timeout (three-tier: litellm SDK, httpx/httpcore transport, bare Connection timed out)
+## After exhausting retries, the caller falls back to the next model.
+is_transient_same_model_retry_error() {
+	if is_rate_limit_error; then
+		return 0
+	fi
+
+	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	# Timeouts are transient — retry the same model before falling back.
+	if is_timeout_error; then
+		return 0
+	fi
+
+	return 1
+}
+
+run_strix_with_transient_retry() {
+	local model="$1"
+	local max_attempts=$((STRIX_TRANSIENT_RETRY_PER_MODEL + 1))
+	local attempt=1
+
+	while [ "$attempt" -le "$max_attempts" ]; do
+		if run_strix_once "$model"; then
+			return 0
+		fi
+
+		if [ "$attempt" -ge "$max_attempts" ]; then
+			return 1
+		fi
+
+		if ! is_transient_same_model_retry_error; then
+			return 1
+		fi
+
+		local retry_reason="transient error"
+		if is_timeout_error; then
+			retry_reason="timeout"
+		elif is_rate_limit_error; then
+			retry_reason="rate limit"
+		elif is_midstream_fallback_error; then
+			retry_reason="midstream fallback"
+		fi
+		echo "Retrying model '$model' due to $retry_reason (attempt $((attempt + 1))/$max_attempts)." >&2
+		sleep "$STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS"
+		attempt=$((attempt + 1))
+	done
+
+	return 1
+}
+
+is_vertex_not_found_error() {
+	# Match Vertex/LiteLLM model-not-found errors.
+	# These functions are only called within the Vertex fallback path
+	# (gated by is_vertex_model), so the risk of matching target-app
+	# 404s is low — strix separates LLM errors from scan findings.
+	if grep -Fq 'litellm.NotFoundError: Vertex_aiException' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Fq 'litellm.NotFoundError' "$STRIX_LOG" && grep -Eq '"status"[[:space:]]*:[[:space:]]*"NOT_FOUND"' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	# Compact Vertex/GCP API error format — require a provider marker
+	# (litellm, VertexAI, or Vertex) nearby so we don't misclassify
+	# target-application 404 JSON responses as LLM provider errors.
+	if grep -Eq '"status"[[:space:]]*:[[:space:]]*"NOT_FOUND"' "$STRIX_LOG" &&
+		grep -Eiq '(litellm|VertexAI|Vertex_ai|vertex\.ai|google\.cloud)' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Eq 'Publisher Model .*was not found' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+is_rate_limit_error() {
+	if grep -Fq 'RateLimitError' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	if grep -Eq '"status"[[:space:]]*:[[:space:]]*"RESOURCE_EXHAUSTED"' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	# Bare HTTP 429 — require a provider marker so we don't misclassify
+	# target-application rate-limit responses as LLM provider errors.
+	if grep -Eq '(^|[^0-9])429([^0-9]|$)' "$STRIX_LOG" &&
+		grep -Eiq '(litellm|RateLimitError|VertexAI|Vertex_ai|vertex\.ai|openai|anthropic)' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+## Timeout classification — three-tier hierarchy:
+##
+##   1. litellm.exceptions.Timeout — SDK-level timeout raised by litellm.
+##      Always trusted as a genuine LLM timeout; no provider marker required.
+##
+##   2. httpx.ReadTimeout / httpcore.ReadTimeout — transport-layer timeouts
+##      from litellm/openai SDK internals. These strings can also appear in
+##      target-application logs, so an LLM-provider marker (LLM_PROVIDER_ONLY_REGEX)
+##      must be present nearby to classify as an LLM timeout.
+##
+##   3. Bare "Connection timed out" — generic OS/network timeout string.
+##      Requires LLM_PROVIDER_ONLY_REGEX to avoid misclassifying target-app
+##      or infrastructure network timeouts as LLM errors.
+##
+## All three tiers feed into is_transient_same_model_retry_error() and trigger
+## the same-model retry loop (up to STRIX_TRANSIENT_RETRY_PER_MODEL attempts)
+## before falling back to the next model in STRIX_VERTEX_FALLBACK_MODELS.
+is_timeout_error() {
+	# Tier 1: litellm SDK timeout — provider-specific, always trusted.
+	if grep -Fq 'litellm.exceptions.Timeout' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	# Tier 2a: httpx transport timeout — requires LLM provider marker.
+	# httpx/httpcore are litellm/openai SDK transport libraries, but their
+	# timeout strings could appear in target-application logs too.
+	# Require an LLM provider-context marker (LLM_PROVIDER_ONLY_REGEX) to
+	# avoid misclassification — the httpx/httpcore/requests transport names
+	# in the timeout string itself are not sufficient proof of an LLM call.
+	if grep -Fq 'httpx.ReadTimeout' "$STRIX_LOG" &&
+		grep -Eiq "$LLM_PROVIDER_ONLY_REGEX" "$STRIX_LOG"; then
+		return 0
+	fi
+
+	# Tier 2b: httpcore transport timeout — requires LLM provider marker.
+	if grep -Fq 'httpcore.ReadTimeout' "$STRIX_LOG" &&
+		grep -Eiq "$LLM_PROVIDER_ONLY_REGEX" "$STRIX_LOG"; then
+		return 0
+	fi
+
+	# Tier 3: Bare "Connection timed out" — require a real LLM provider-context
+	# marker.  httpx/httpcore/requests are transport libraries that could
+	# appear in any network timeout context, so they are NOT valid markers
+	# here.  Use LLM_PROVIDER_ONLY_REGEX (defined alongside
+	# PROVIDER_CONTEXT_REGEX) to prevent drift.
+	if grep -Fq 'Connection timed out' "$STRIX_LOG" &&
+		grep -Eiq "$LLM_PROVIDER_ONLY_REGEX" "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+is_midstream_fallback_error() {
+	if grep -Fq 'MidStreamFallbackError' "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+# Centralised provider-context regex.
+# Many error classifiers require a provider/SDK marker nearby to distinguish
+# LLM-level errors from target-application log noise.  Keeping a single
+# constant prevents drift across functions.
+#
+# Includes both LLM providers and HTTP transport libraries (httpx, httpcore,
+# requests) because for most error paths (rate-limit, midstream fallback,
+# httpx/httpcore.ReadTimeout) transport library presence is sufficient to
+# confirm the log line originates from the LLM SDK stack.
+#
+# See LLM_PROVIDER_ONLY_REGEX below for the narrower variant that excludes
+# transport libraries — used only by the bare "Connection timed out" path.
+PROVIDER_CONTEXT_REGEX='(litellm|openai|anthropic|VertexAI|Vertex_ai|vertex\.ai|google\.cloud|httpx|httpcore|requests)'
+
+# Narrower variant: LLM providers only, excluding HTTP transport libraries
+# (httpx, httpcore, requests).  Used exclusively by the bare "Connection
+# timed out" path in is_timeout_error() where transport-library names alone
+# are not sufficient to classify a generic OS/network timeout as an LLM error.
+#
+# Rationale: httpx/httpcore/requests can appear in any Python application's
+# network timeout logs.  Only genuine LLM provider names (litellm, openai,
+# anthropic, Vertex variants, google.cloud) confirm the timeout is LLM-related.
+LLM_PROVIDER_ONLY_REGEX='(litellm|openai|anthropic|VertexAI|Vertex_ai|vertex\.ai|google\.cloud)'
+
+has_provider_context_marker() {
+	grep -Eiq "$PROVIDER_CONTEXT_REGEX" "$STRIX_LOG"
+}
+
+# Detect whether the strix log contains evidence of infrastructure-level
+# errors (timeout, rate-limit, transport failures) that indicate the scan
+# was interrupted or incomplete.  Used as a guard to prevent the
+# below-threshold override from silently passing an aborted scan.
+has_detected_infrastructure_error() {
+	if is_timeout_error; then
+		return 0
+	fi
+
+	if is_rate_limit_error; then
+		return 0
+	fi
+
+	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	# Generic strix non-zero exit with known transport/connection errors
+	# that don't fall into the specific categories above.
+	# Use LLM_PROVIDER_ONLY_REGEX (not PROVIDER_CONTEXT_REGEX) to avoid
+	# false positives: PROVIDER_CONTEXT_REGEX includes httpx/httpcore/requests
+	# which would self-match on e.g. "requests.exceptions.ConnectionError"
+	# from target-application logs.
+	if grep -Eiq '(ConnectionError|ConnectionRefusedError|ConnectionResetError|SSLError|ProxyError|NetworkError)' "$STRIX_LOG" &&
+		grep -Eiq "$LLM_PROVIDER_ONLY_REGEX" "$STRIX_LOG"; then
+		return 0
+	fi
+
+	return 1
+}
+
+latest_strix_report_dir() {
+	local latest=""
+	local run_dir
+
+	for run_dir in "$STRIX_REPORTS_DIR"/*; do
+		if [ ! -d "$run_dir" ] || [ -L "$run_dir" ]; then
+			continue
+		fi
+
+		if is_preexisting_report_dir "$run_dir"; then
+			continue
+		fi
+
+		if [ -z "$latest" ] || [ "$run_dir" -nt "$latest" ]; then
+			latest="$run_dir"
+		fi
+	done
+
+	if [ -z "$latest" ]; then
+		return 1
+	fi
+
+	echo "$latest"
+}
+
+has_only_below_threshold_vulnerabilities() {
+	local threshold_rank
+	threshold_rank="$(severity_rank "$STRIX_FAIL_ON_MIN_SEVERITY")"
+
+	local found_any_report=0
+	local found_any_vuln_file=0
+	local global_max_rank=-1
+	local saw_any_severity=0
+
+	local run_dir
+	for run_dir in "$STRIX_REPORTS_DIR"/*; do
+		if [ ! -d "$run_dir" ] || [ -L "$run_dir" ]; then
+			continue
+		fi
+
+		if is_preexisting_report_dir "$run_dir"; then
+			continue
+		fi
+
+		local vulnerabilities_dir="$run_dir/vulnerabilities"
+		if [ ! -d "$vulnerabilities_dir" ] || [ -L "$vulnerabilities_dir" ]; then
+			continue
+		fi
+
+		found_any_report=1
+		local vuln_file
+		local line
+		local severity
+		local rank
+
+		for vuln_file in "$vulnerabilities_dir"/*.md; do
+			if [ ! -f "$vuln_file" ] || [ -L "$vuln_file" ]; then
+				continue
+			fi
+
+			found_any_vuln_file=1
+
+			while IFS= read -r line; do
+				if [[ "${line^^}" =~ SEVERITY[[:space:]]*:[[:space:][:punct:]]*(CRITICAL|HIGH|MEDIUM|LOW|INFO|INFORMATIONAL|NONE)([[:space:][:punct:]]|$) ]]; then
+					severity="${BASH_REMATCH[1]}"
+				else
+					continue
+				fi
+
+				rank="$(severity_rank "$severity")"
+				if [ "$rank" -lt 0 ]; then
+					continue
+				fi
+
+				saw_any_severity=1
+				if [ "$rank" -gt "$global_max_rank" ]; then
+					global_max_rank="$rank"
+				fi
+			done < <(grep -Ei 'severity[[:space:]]*:' "$vuln_file" || true)
+		done
+	done
+
+	if [ "$found_any_report" -eq 0 ]; then
+		return 1
+	fi
+
+	# Guard against incomplete/aborted scans: if reports exist but no
+	# vulnerability files were found, the scan likely aborted before
+	# completing its analysis — refuse the bypass.
+	if [ "$found_any_vuln_file" -eq 0 ]; then
+		echo "Reports exist but contain no vulnerability files; scan may be incomplete." >&2
+		return 1
+	fi
+
+	if [ "$saw_any_severity" -eq 0 ]; then
+		return 1
+	fi
+
+	# Guard against incomplete scans due to infrastructure errors.
+	# Use the sticky INFRA_ERROR_DETECTED flag instead of re-reading
+	# STRIX_LOG, because STRIX_LOG is overwritten per-attempt.  If an
+	# earlier attempt hit an infrastructure error (timeout, rate-limit,
+	# transport failure) and produced a partial report that now sits in
+	# the reports directory, the *current* STRIX_LOG may show a different
+	# failure — or even success — but the partial report's low-severity
+	# findings must not be treated as a clean scan result.
+	if [ "$INFRA_ERROR_DETECTED" -eq 1 ]; then
+		echo "Below-threshold findings detected, but infrastructure errors occurred during this pipeline run; refusing bypass due to potentially incomplete scan." >&2
+		return 1
+	fi
+
+	if [ "$global_max_rank" -lt "$threshold_rank" ]; then
+		echo "Strix findings are below configured fail threshold '$STRIX_FAIL_ON_MIN_SEVERITY'; allowing pipeline continuation." >&2
+		return 0
+	fi
+
+	return 1
+}
+
+is_hallucinated_endpoint_finding() {
+	# Configurable list of source directories to check for endpoints.
+	# Defaults to "." (i.e. TARGET_PATH itself) so that both
+	# STRIX_TARGET_PATH=./ and STRIX_TARGET_PATH=./src work correctly
+	# without producing bogus double-nested paths like ./src/src.
+	# Set STRIX_SOURCE_DIRS (space-separated) to override.
+	local source_dirs_raw="${STRIX_SOURCE_DIRS:-.}"
+	local resolved_dirs=()
+	local dir_entry
+
+	# Disable globbing so that entries like "*" or "[" in STRIX_SOURCE_DIRS
+	# are not expanded by pathname expansion during word-splitting.
+	set -f
+	for dir_entry in $source_dirs_raw; do
+		local candidate="${TARGET_PATH%/}/$dir_entry"
+		if [ -d "$candidate" ] && [ ! -L "$candidate" ]; then
+			resolved_dirs+=("$candidate")
+		fi
+	done
+	set +f
+
+	if [ "${#resolved_dirs[@]}" -eq 0 ]; then
+		return 1
+	fi
+
+	local latest_report_dir
+	if ! latest_report_dir="$(latest_strix_report_dir)"; then
+		return 1
+	fi
+
+	local endpoint_seen=0
+	local endpoint_present_in_source=0
+	local endpoint
+	local vuln_file
+
+	for vuln_file in "$latest_report_dir"/vulnerabilities/*.md; do
+		if [ ! -f "$vuln_file" ] || [ -L "$vuln_file" ]; then
+			continue
+		fi
+
+		while IFS= read -r endpoint; do
+			if [ -z "$endpoint" ]; then
+				continue
+			fi
+
+			endpoint_seen=1
+			local search_dir
+			for search_dir in "${resolved_dirs[@]}"; do
+				# Exclude the strix reports directory and common non-source
+				# directories from the source search to prevent accidental
+				# matches and reduce runtime (especially when STRIX_TARGET_PATH=./).
+				#
+				# Each exclude-dir:
+				#   STRIX_REPORTS_DIR — strix output itself (would always match).
+				#       Both the full path and basename are excluded so that
+				#       nested paths like "reports/strix_runs" are also caught.
+				#   .git             — VCS internals
+				#   node_modules     — JS/TS dependencies (may contain API strings)
+				#   vendor           — Go/PHP vendored deps
+				#   __pycache__      — Python bytecode cache
+				#   .venv            — Python virtualenv
+				#   target           — Rust/Java build artifacts
+				#   .mypy_cache      — mypy type-check cache
+				#   .pytest_cache    — pytest result cache
+				#   dist             — common build output directory
+				#   build            — common build output directory
+				#   .tox             — Python tox test environments
+				#   .ruff_cache      — Ruff linter cache
+				if grep -r -Fq \
+					--exclude-dir="$STRIX_REPORTS_DIR" \
+					--exclude-dir="$(basename "$STRIX_REPORTS_DIR")" \
+					--exclude-dir=".git" \
+					--exclude-dir="node_modules" \
+					--exclude-dir="vendor" \
+					--exclude-dir="__pycache__" \
+					--exclude-dir=".venv" \
+					--exclude-dir="target" \
+					--exclude-dir=".mypy_cache" \
+					--exclude-dir=".pytest_cache" \
+					--exclude-dir="dist" \
+					--exclude-dir="build" \
+					--exclude-dir=".tox" \
+					--exclude-dir=".ruff_cache" \
+					-- "$endpoint" "$search_dir"; then
+					endpoint_present_in_source=1
+					break
+				fi
+			done
+			if [ "$endpoint_present_in_source" -eq 1 ]; then
+				break
+			fi
+		done < <(grep -Eo '/api/[[:alnum:]_./-]+' "$vuln_file" | sort -u)
+
+		if [ "$endpoint_present_in_source" -eq 1 ]; then
+			break
+		fi
+	done
+
+	if [ "$endpoint_seen" -eq 0 ]; then
+		return 1
+	fi
+
+	if [ "$endpoint_present_in_source" -eq 1 ]; then
+		return 1
+	fi
+
+	echo "Detected Strix report endpoint(s) absent from source; treating as retryable model inconsistency." >&2
+	return 0
+}
+
+is_vertex_retryable_error() {
+	if is_vertex_not_found_error; then
+		return 0
+	fi
+
+	if is_rate_limit_error; then
+		return 0
+	fi
+
+	if is_timeout_error; then
+		return 0
+	fi
+
+	if is_midstream_fallback_error; then
+		return 0
+	fi
+
+	if is_hallucinated_endpoint_finding; then
+		return 0
+	fi
+
+	return 1
+}
+
+if run_strix_with_transient_retry "$PRIMARY_MODEL"; then
+	exit 0
+fi
+
+if has_only_below_threshold_vulnerabilities; then
+	exit 0
+fi
+
+if ! is_vertex_model "$PRIMARY_MODEL"; then
+	echo "Strix quick scan failed with a non-recoverable error." >&2
+	exit 1
+fi
+
+if ! is_vertex_retryable_error; then
+	echo "Strix quick scan failed with a non-recoverable error." >&2
+	exit 1
+fi
+
+if [ -z "${STRIX_VERTEX_FALLBACK_MODELS+x}" ]; then
+	FALLBACK_MODELS_RAW="vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash"
+else
+	FALLBACK_MODELS_RAW="$STRIX_VERTEX_FALLBACK_MODELS"
+fi
+FALLBACK_MODELS_RAW="${FALLBACK_MODELS_RAW//$'\r'/ }"
+FALLBACK_MODELS_RAW="${FALLBACK_MODELS_RAW//$'\n'/ }"
+read -r -a FALLBACK_MODELS <<<"$FALLBACK_MODELS_RAW"
+
+fallback_tried=0
+for candidate_raw in "${FALLBACK_MODELS[@]}"; do
+	candidate="$(normalize_model "$candidate_raw")"
+	if [ -z "$candidate" ] || [ "$candidate" = "$PRIMARY_MODEL" ]; then
+		if [ -n "$candidate" ]; then
+			echo "Skipping fallback model '$candidate' — same as primary model." >&2
+		fi
+		continue
+	fi
+
+	fallback_tried=1
+	echo "Primary Vertex model unavailable; retrying with fallback '$candidate'."
+	if run_strix_with_transient_retry "$candidate"; then
+		echo "Strix quick scan succeeded with fallback model '$candidate'."
+		exit 0
+	fi
+
+	if has_only_below_threshold_vulnerabilities; then
+		exit 0
+	fi
+
+	if ! is_vertex_retryable_error; then
+		echo "Strix quick scan failed with a non-recoverable error." >&2
+		exit 1
+	fi
+done
+
+## Differentiated fallback error messaging:
+## - Empty STRIX_VERTEX_FALLBACK_MODELS → "No fallback models configured"
+## - All entries match primary → "All configured fallback models are the same"
+## This prevents the misleading "all same as primary" message when no models
+## were configured at all.
+if [ "$fallback_tried" -eq 0 ]; then
+	if [ "${#FALLBACK_MODELS[@]}" -eq 0 ]; then
+		echo "ERROR: No fallback models configured (STRIX_VERTEX_FALLBACK_MODELS is empty). Configure distinct models." >&2
+	else
+		echo "ERROR: All configured fallback models are the same as the primary model '$PRIMARY_MODEL'. Configure distinct models in STRIX_VERTEX_FALLBACK_MODELS." >&2
+	fi
+fi
+
+echo "Configured Vertex model and fallback models were unavailable." >&2
+exit 1

--- a/scripts/ci/test_strix_quick_gate.sh
+++ b/scripts/ci/test_strix_quick_gate.sh
@@ -1,0 +1,1760 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(CDPATH= cd -P -- "$SCRIPT_DIR/../.." && pwd -P)"
+GATE_SCRIPT="$REPO_ROOT/scripts/ci/strix_quick_gate.sh"
+
+FAILURES=0
+
+record_failure() {
+	echo "FAIL: $1" >&2
+	FAILURES=$((FAILURES + 1))
+}
+
+assert_equals() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+
+	if [ "$expected" != "$actual" ]; then
+		record_failure "$message (expected='$expected' actual='$actual')"
+	fi
+}
+
+assert_file_contains() {
+	local file_path="$1"
+	local needle="$2"
+	local message="$3"
+
+	if ! grep -Fq -- "$needle" "$file_path"; then
+		record_failure "$message (missing '$needle')"
+	fi
+}
+
+run_gate_case() {
+	local scenario="$1"
+	local initial_model="$2"
+	local fallback_models="$3"
+	local expected_exit="$4"
+	local expected_message="$5"
+	local expected_calls="$6"
+	local expected_model_sequence="${7:-}"
+	local expected_api_base_sequence="${8:-}"
+	local default_provider="${9-vertex_ai}"
+	local raw_llm_api_base_override="${10-__DEFAULT__}"
+	local initial_llm_api_base="${11-}"
+
+	local raw_llm_api_base="https://example.invalid/generateContent"
+	if [ "$raw_llm_api_base_override" != "__DEFAULT__" ]; then
+		raw_llm_api_base="$raw_llm_api_base_override"
+	fi
+	local transient_retry_per_model="${12-0}"
+	local min_fail_severity="${13-CRITICAL}"
+	local transient_retry_backoff_seconds="${14-0}"
+	local custom_target_path="${15-}"
+	local custom_source_dirs="${16-}"
+
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	# Separate bin/ (fake strix + helper files) from workspace/ (target path)
+	# so grep -r over the target path never matches the fake strix script itself.
+	local bin_dir="$tmp_dir/bin"
+	local workspace_dir="$tmp_dir/workspace"
+	mkdir -p "$bin_dir" "$workspace_dir/src"
+	local fake_strix="$bin_dir/strix"
+	local call_log="$tmp_dir/calls.log"
+	local api_base_log="$tmp_dir/api_base.log"
+	local state_file="$tmp_dir/state.log"
+	local output_log="$tmp_dir/output.log"
+
+	# Resolve target path: use custom if provided, else default to $workspace_dir.
+	local effective_target_path="$workspace_dir"
+	if [ "$custom_target_path" = "__USE_SUBDIR_SRC__" ]; then
+		# Simulate STRIX_TARGET_PATH=./src by using $workspace_dir/src.
+		effective_target_path="$workspace_dir/src"
+	elif [ -n "$custom_target_path" ]; then
+		effective_target_path="$custom_target_path"
+		# Ensure the custom target path exists
+		mkdir -p "$effective_target_path"
+	fi
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "${STRIX_LLM:-}" >> "${FAKE_STRIX_CALL_LOG:?}"
+echo "${LLM_API_BASE:-<unset>}" >> "${FAKE_STRIX_API_BASE_LOG:?}"
+
+STRIX_REPORTS_DIR="${STRIX_REPORTS_DIR:-strix_runs}"
+
+case "${FAKE_STRIX_SCENARIO:?}" in
+	success|vertex-primary-success-timing-message)
+		echo "scan ok"
+		exit 0
+		;;
+	vertex-primary-notfound-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok with fallback"
+			exit 0
+			;;
+		*)
+			echo "unexpected model ${STRIX_LLM:-}" >&2
+			exit 9
+			;;
+		esac
+		;;
+	vertex-all-notfound)
+		echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+		echo '"status": "NOT_FOUND"'
+		exit 1
+		;;
+	nonrecoverable)
+		echo "Error: transport timeout"
+		exit 1
+		;;
+	provider-prefix-required)
+		if [ "${STRIX_LLM:-}" = "vertex_ai/gemini-2.5-pro" ]; then
+			echo "scan ok with normalized provider"
+			exit 0
+		fi
+		echo "Error: provider prefix not normalized (${STRIX_LLM:-})" >&2
+		exit 10
+		;;
+	provider-prefix-fallback-normalization)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after fallback normalization"
+			exit 0
+			;;
+		*)
+			echo "Error: fallback provider prefix not normalized (${STRIX_LLM:-})" >&2
+			exit 11
+			;;
+		esac
+		;;
+	provider-prefix-required-resource-path-primary-implicit-default-provider | provider-prefix-required-resource-path-primary-explicit-empty-default-provider)
+		if [ "${STRIX_LLM:-}" = "vertex_ai/gemini-2.5-pro" ]; then
+			echo "scan ok with resource-path normalization"
+			exit 0
+		fi
+		echo "Error: resource-path model not normalized (${STRIX_LLM:-})" >&2
+		exit 12
+		;;
+	provider-prefix-resource-path-primary-notfound-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after resource-path fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: resource-path fallback model not normalized (${STRIX_LLM:-})" >&2
+			exit 13
+			;;
+		esac
+		;;
+	vertex-custom-model-resource-path)
+		# projects/<p>/locations/<l>/models/<id> (no publishers/ segment)
+		if [ "${STRIX_LLM:-}" = "vertex_ai/my-custom-model-123" ]; then
+			echo "scan ok with custom model resource-path normalization"
+			exit 0
+		fi
+		echo "Error: custom model resource-path not normalized (${STRIX_LLM:-})" >&2
+		exit 40
+		;;
+	vertex-notfound-without-status-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after status-less not found fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: status-less fallback model not normalized (${STRIX_LLM:-})" >&2
+			exit 14
+			;;
+		esac
+		;;
+	vertex-notfound-compact-status-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo 'litellm.exceptions.NotFoundError: VertexAI error'
+			echo '{"error":{"status":"NOT_FOUND"}}'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after compact-status not found fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: compact-status fallback model not normalized (${STRIX_LLM:-})" >&2
+			exit 17
+			;;
+		esac
+		;;
+	nonvertex-slash-model-passthrough)
+		if [ "${STRIX_LLM:-}" = "foo/bar" ]; then
+			echo "scan ok with non-vertex slash model passthrough"
+			exit 0
+		fi
+		echo "Error: non-vertex slash model was rewritten (${STRIX_LLM:-})" >&2
+		exit 18
+		;;
+	primary-duplicate-in-fallback)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after duplicate-primary skip"
+			exit 0
+			;;
+		*)
+			echo "Error: duplicate-primary path unexpected (${STRIX_LLM:-})" >&2
+			exit 15
+			;;
+		esac
+		;;
+	multiline-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/fallback-two)
+			echo "scan ok after multiline fallback parsing"
+			exit 0
+			;;
+		*)
+			echo "Error: multiline fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 19
+			;;
+		esac
+		;;
+	vertex-primary-ratelimit-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/ratelimit-primary)
+			echo "Penetration test failed: LLM request failed: RateLimitError"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after rate-limit fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: ratelimit fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 21
+			;;
+		esac
+		;;
+	vertex-primary-resource-exhausted-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/resource-exhausted-primary)
+			echo '{"error":{"status":"RESOURCE_EXHAUSTED"}}'
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after resource exhausted fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: resource exhausted fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 23
+			;;
+		esac
+		;;
+	vertex-primary-429-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/http429-primary)
+			echo "litellm: HTTP 429 Too Many Requests"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after 429 fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: 429 fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 24
+			;;
+		esac
+		;;
+	vertex-primary-midstream-fallback-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/midstream-primary)
+			echo "Penetration test failed: LLM request failed: MidStreamFallbackError"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after midstream fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: midstream fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 25
+			;;
+		esac
+		;;
+	vertex-primary-midstream-retry-same-model-success)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/retry-midstream-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" > "${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "Penetration test failed: LLM request failed: MidStreamFallbackError"
+				exit 1
+			fi
+			echo "scan ok after same-model retry"
+			exit 0
+			;;
+		*)
+			echo "Error: same-model retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 30
+			;;
+		esac
+		;;
+	vertex-primary-ratelimit-retry-same-model-success|vertex-primary-ratelimit-retry-reason-message)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/retry-ratelimit-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" > "${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "Penetration test failed: LLM request failed: RateLimitError"
+				exit 1
+			fi
+			echo "scan ok after same-model rate-limit retry"
+			exit 0
+			;;
+		*)
+			echo "Error: same-model rate-limit retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 31
+			;;
+		esac
+		;;
+	vertex-all-ratelimited)
+		echo "Penetration test failed: LLM request failed: RateLimitError"
+		exit 1
+		;;
+	vertex-primary-hallucinated-endpoint-fallback-success|target-path-src-default-source-dirs)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/hallucination-primary)
+			mkdir -p "$STRIX_REPORTS_DIR/fake-hallucinated/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/fake-hallucinated/vulnerabilities/vuln-0001.md" <<'EOS'
+**Endpoint:** /api/ghost-admin
+EOS
+			echo "Penetration test failed: CRITICAL finding on /api/ghost-admin"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after hallucinated-endpoint fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: hallucinated-endpoint fallback path unexpected (${STRIX_LLM:-})" >&2
+			exit 26
+			;;
+		esac
+		;;
+	vertex-primary-existing-endpoint-nonrecoverable|multi-source-dirs-existing-endpoint)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/existing-endpoint-primary|vertex_ai/multi-dir-primary)
+			mkdir -p "$STRIX_REPORTS_DIR/fake-existing-endpoint/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/fake-existing-endpoint/vulnerabilities/vuln-0001.md" <<'EOS'
+**Endpoint:** /api/status
+EOS
+			echo "Penetration test failed: CRITICAL finding on /api/status"
+			exit 1
+			;;
+		vertex_ai/fallback-one|vertex_ai/fallback-two)
+			echo "Error: existing endpoint findings must remain non-recoverable (${STRIX_LLM:-})" >&2
+			exit 27
+			;;
+		*)
+			echo "Error: existing-endpoint scenario unexpected model (${STRIX_LLM:-})" >&2
+			exit 28
+			;;
+		esac
+		;;
+	endpoint-in-excluded-dir)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/excluded-dir-primary)
+			mkdir -p "$STRIX_REPORTS_DIR/fake-excluded-dir/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/fake-excluded-dir/vulnerabilities/vuln-0001.md" <<'EOS'
+**Endpoint:** /api/hidden-secret
+EOS
+			echo "Penetration test failed: CRITICAL finding on /api/hidden-secret"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after excluded-dir hallucination fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: excluded-dir scenario unexpected model (${STRIX_LLM:-})" >&2
+			exit 29
+			;;
+		esac
+		;;
+	empty-fallback-models)
+		# Output must match is_vertex_not_found_error() patterns so the gate
+		# proceeds to the fallback loop (where empty array triggers the message).
+		echo "Publisher Model vertex_ai/empty-fb-primary was not found in project."
+		exit 1
+		;;
+	high-vuln-below-threshold)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-high/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-high/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: HIGH
+EOS
+		echo "Penetration test failed: simulated high finding"
+		exit 1
+		;;
+	critical-vuln-at-threshold)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-critical/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-critical/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: CRITICAL
+EOS
+		echo "Penetration test failed: simulated critical finding"
+		exit 1
+		;;
+	malformed-severity-marker-nonrecoverable)
+		mkdir -p "$STRIX_REPORTS_DIR/fake-malformed/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-malformed/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity details: high confidence marker only
+EOS
+		echo "Penetration test failed: malformed severity marker"
+		exit 1
+		;;
+	model-disagreement-critical-in-earlier-report)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/model-a)
+			mkdir -p "$STRIX_REPORTS_DIR/run-001/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/run-001/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: CRITICAL
+EOS
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			echo "Penetration test failed: CRITICAL finding by model-a"
+			exit 1
+			;;
+		vertex_ai/model-b)
+			mkdir -p "$STRIX_REPORTS_DIR/run-002/vulnerabilities"
+			cat >"$STRIX_REPORTS_DIR/run-002/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: LOW
+EOS
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			echo "Penetration test failed: LOW finding by model-b"
+			exit 1
+			;;
+		*)
+			echo "Error: model-disagreement unexpected model (${STRIX_LLM:-})" >&2
+			exit 32
+			;;
+		esac
+		;;
+	nonvertex-slash-model-not-rewritten)
+		if [ "${STRIX_LLM:-}" = "deepseek/models/deepseek-r1" ]; then
+			echo "scan ok with deepseek model passthrough"
+			exit 0
+		fi
+		echo "Error: deepseek model was rewritten (${STRIX_LLM:-})" >&2
+		exit 33
+		;;
+	preserve-existing-api-base)
+		if [ "${LLM_API_BASE:-}" = "https://preexisting.invalid" ]; then
+			echo "scan ok with preserved api base"
+			exit 0
+		fi
+		echo "Error: existing LLM_API_BASE was not preserved (${LLM_API_BASE:-<unset>})" >&2
+		exit 20
+		;;
+	default-fallback-order-fast-first)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/missing-primary)
+			echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+			echo '"status": "NOT_FOUND"'
+			exit 1
+			;;
+		vertex_ai/gemini-2.5-pro)
+			echo "scan ok with default fast fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: default fallback order unexpected (${STRIX_LLM:-})" >&2
+			exit 16
+			;;
+		esac
+		;;
+	vertex-primary-timeout-retry-same-model-success|vertex-primary-timeout-retry-reason-message)
+		case "${STRIX_LLM:-}" in
+		vertex_ai/retry-timeout-primary)
+			attempt="0"
+			if [ -f "${FAKE_STRIX_STATE_FILE:?}" ]; then
+				attempt="$(cat "${FAKE_STRIX_STATE_FILE:?}")"
+			fi
+			attempt="$((attempt + 1))"
+			echo "$attempt" > "${FAKE_STRIX_STATE_FILE:?}"
+			if [ "$attempt" -eq 1 ]; then
+				echo "litellm.exceptions.Timeout: litellm.Timeout: Connection timed out after None seconds."
+				exit 1
+			fi
+			echo "scan ok after same-model timeout retry"
+			exit 0
+			;;
+		*)
+			echo "Error: same-model timeout retry path unexpected (${STRIX_LLM:-})" >&2
+			exit 34
+			;;
+		esac
+		;;
+	all-fallbacks-same-as-primary)
+		# Bug 13: All fallback models are the same as the primary model.
+		# The gate should emit an ERROR and exit 1.
+		echo "Error: litellm.NotFoundError: Vertex_aiException - x"
+		echo '"status": "NOT_FOUND"'
+		exit 1
+		;;
+	vertex-primary-timeout-exhausted-fallback-success)
+		# Primary always times out (even after retries). Fallback succeeds.
+		case "${STRIX_LLM:-}" in
+		vertex_ai/timeout-exhaust-primary)
+			echo "litellm.exceptions.Timeout: litellm.Timeout: Connection timed out after None seconds."
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after timeout-exhausted fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: timeout-exhausted-fallback unexpected model (${STRIX_LLM:-})" >&2
+			exit 35
+			;;
+		esac
+		;;
+	bare-timeout-with-provider-marker)
+		# Emit bare "Connection timed out" alongside a provider marker so
+		# is_timeout_error() matches the Tier 3 branch gated on
+		# LLM_PROVIDER_ONLY_REGEX.  Does NOT include
+		# litellm.exceptions.Timeout / httpx.ReadTimeout to ensure we
+		# exercise the provider-marker fallback path specifically.
+		# First call times out; same-model retry succeeds.
+		if [ -f "$FAKE_STRIX_STATE_FILE" ]; then
+			echo "scan ok after bare-timeout-with-provider retry"
+			exit 0
+		fi
+		touch "$FAKE_STRIX_STATE_FILE"
+		echo "Connection timed out"
+		echo "vertex_ai model invocation failed"
+		exit 1
+		;;
+	bare-timeout-no-provider-marker)
+		# Emit "Connection timed out" with transport library names (httpx,
+		# httpcore, requests) but WITHOUT any real LLM provider marker.
+		# is_timeout_error() Tier 3 uses LLM_PROVIDER_ONLY_REGEX which
+		# excludes transport libs, so this should NOT match.
+		echo "Connection timed out"
+		echo "httpx transport layer connection reset"
+		echo "httpcore pool timeout"
+		echo "requests transport timeout"
+		exit 1
+		;;
+	below-threshold-with-timeout)
+		# Produce a below-threshold (LOW) finding but also emit a timeout error
+		# so the infrastructure guard detects an incomplete scan.
+		mkdir -p "$STRIX_REPORTS_DIR/fake-low-timeout/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-low-timeout/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: LOW
+EOS
+		echo "litellm.exceptions.Timeout: litellm.Timeout: Connection timed out after None seconds."
+		echo "Penetration test failed: simulated timeout with low finding"
+		exit 1
+		;;
+	below-threshold-with-ratelimit)
+		# Produce a below-threshold (LOW) finding but also emit a rate-limit error.
+		mkdir -p "$STRIX_REPORTS_DIR/fake-low-ratelimit/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-low-ratelimit/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: LOW
+EOS
+		echo "Penetration test failed: LLM request failed: RateLimitError"
+		echo "Penetration test failed: simulated ratelimit with low finding"
+		exit 1
+		;;
+	below-threshold-with-connection-error)
+		# Produce a below-threshold (INFO) finding but also emit a
+		# ConnectionError WITH an LLM-provider context marker so the
+		# infrastructure guard detects an incomplete scan.
+		# The two-grep guard requires BOTH a transport error class AND an
+		# LLM_PROVIDER_ONLY_REGEX marker (litellm, openai, anthropic, etc.).
+		mkdir -p "$STRIX_REPORTS_DIR/fake-info-conn/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-info-conn/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: INFO
+EOS
+		echo "litellm.exceptions.APIConnectionError: ConnectionError - connection refused"
+		echo "Penetration test failed: simulated connection error with info finding"
+		exit 1
+		;;
+	below-threshold-with-connection-error-no-provider)
+		# Produce a below-threshold (INFO) finding and emit a ConnectionError
+		# WITHOUT any LLM-provider context marker.  The infra-error detector
+		# should NOT match because the log lacks provider markers like
+		# "litellm", "openai", "anthropic", etc.  This validates that the
+		# two-grep guard avoids false positives from target-application logs.
+		mkdir -p "$STRIX_REPORTS_DIR/fake-info-conn-noprov/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-info-conn-noprov/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: INFO
+EOS
+		echo "ConnectionError: target server refused connection on port 8443"
+		echo "Penetration test failed: simulated app-level connection error"
+		exit 1
+		;;
+	below-threshold-with-requests-connection-error)
+		# Produce a below-threshold (INFO) finding with a
+		# requests.exceptions.ConnectionError — the transport library prefix
+		# "requests" matches the broad PROVIDER_CONTEXT_REGEX but is
+		# intentionally excluded from LLM_PROVIDER_ONLY_REGEX.
+		#
+		# Before commit 0e90d48, the connection-error path used
+		# has_provider_context_marker() (PROVIDER_CONTEXT_REGEX) and would
+		# have incorrectly classified this as an LLM infrastructure error.
+		# After that fix, LLM_PROVIDER_ONLY_REGEX is used, so "requests"
+		# alone does NOT satisfy the provider check → below-threshold bypass
+		# succeeds → exit 0.
+		mkdir -p "$STRIX_REPORTS_DIR/fake-info-conn-requests/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-info-conn-requests/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: INFO
+EOS
+		echo "requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.example.com', port=443): Max retries exceeded with url: /v1/scan"
+		echo "Penetration test failed: simulated requests transport error"
+		exit 1
+		;;
+	below-threshold-with-midstream)
+		# Produce a below-threshold (MEDIUM) finding below CRITICAL threshold
+		# but also emit a MidStreamFallbackError.
+		mkdir -p "$STRIX_REPORTS_DIR/fake-medium-midstream/vulnerabilities"
+		cat >"$STRIX_REPORTS_DIR/fake-medium-midstream/vulnerabilities/vuln-0001.md" <<'EOS'
+Severity: MEDIUM
+EOS
+		echo "Penetration test failed: LLM request failed: MidStreamFallbackError"
+		echo "Penetration test failed: simulated midstream with medium finding"
+		exit 1
+		;;
+	bare-timeout-provider-marker-exhausted-fallback)
+		# Bare "Connection timed out" + provider marker: primary always fails
+		# (even after transient retries). Gate exhausts retries on primary,
+		# then falls back to fallback-one which succeeds.
+		case "${STRIX_LLM:-}" in
+		vertex_ai/bare-timeout-exhaust-primary)
+			echo "Connection timed out"
+			echo "vertex_ai model invocation failed"
+			exit 1
+			;;
+		vertex_ai/fallback-one)
+			echo "scan ok after bare-timeout-exhaust fallback"
+			exit 0
+			;;
+		*)
+			echo "Error: bare-timeout-exhaust-fallback unexpected model (${STRIX_LLM:-})" >&2
+			exit 35
+			;;
+		esac
+		;;
+	httpx-read-timeout-with-provider-marker)
+		# Tier 2: httpx.ReadTimeout + provider-context marker (litellm).
+		# First call times out; same-model retry succeeds.
+		if [ -f "$FAKE_STRIX_STATE_FILE" ]; then
+			echo "scan ok after httpx-timeout retry"
+			exit 0
+		fi
+		touch "$FAKE_STRIX_STATE_FILE"
+		echo "httpx.ReadTimeout: timed out"
+		echo "litellm.proxy: connection to upstream model failed"
+		exit 1
+		;;
+	httpx-read-timeout-no-provider-marker)
+		# Tier 2 negative: httpx.ReadTimeout WITHOUT any provider-context
+		# marker.  Should NOT be classified as retryable timeout.
+		echo "httpx.ReadTimeout: timed out"
+		echo "application server connection pool exhausted"
+		exit 1
+		;;
+	httpcore-read-timeout-with-provider-marker)
+		# Tier 2b: httpcore.ReadTimeout + provider-context marker.
+		# First call times out; same-model retry succeeds.
+		if [ -f "$FAKE_STRIX_STATE_FILE" ]; then
+			echo "scan ok after httpcore-timeout retry"
+			exit 0
+		fi
+		touch "$FAKE_STRIX_STATE_FILE"
+		echo "httpcore.ReadTimeout: timed out"
+		echo "litellm.proxy: connection to upstream model failed"
+		exit 1
+		;;
+	httpcore-read-timeout-no-provider-marker)
+		# Tier 2b negative: httpcore.ReadTimeout WITHOUT any provider-context
+		# marker.  Should NOT be classified as retryable timeout.
+		echo "httpcore.ReadTimeout: timed out"
+		echo "application server connection pool exhausted"
+		exit 1
+		;;
+	infra-error-sticky-flag)
+		# Sticky flag test: first call hits infra error (rate limit),
+		# second call fails with a non-retryable error but produces a
+		# LOW finding report.  After exhausting retries, the gate checks
+		# has_only_below_threshold_vulnerabilities — which finds LOW
+		# findings but sees INFRA_ERROR_DETECTED=1 (set from the first
+		# call's rate-limit error) and refuses the below-threshold bypass.
+		case "${STRIX_LLM:-}" in
+		vertex_ai/sticky-flag-primary)
+			if [ -f "$FAKE_STRIX_STATE_FILE" ]; then
+				# Second call: non-retryable failure with a partial LOW report
+				mkdir -p "$STRIX_REPORTS_DIR/run-sticky/vulnerabilities"
+				cat > "$STRIX_REPORTS_DIR/run-sticky/vulnerabilities/vuln-0001.md" <<'FINDINGS'
+Severity: LOW
+FINDINGS
+				echo "non-retryable scan error with partial results"
+				exit 1
+			fi
+			touch "$FAKE_STRIX_STATE_FILE"
+			echo "RateLimitError: rate limit exceeded"
+			echo "litellm.proxy: rate limit on vertex_ai model"
+			exit 1
+			;;
+		*)
+			echo "Error: infra-error-sticky-flag unexpected model (${STRIX_LLM:-})" >&2
+			exit 35
+			;;
+		esac
+		;;
+	*)
+		echo "unknown scenario ${FAKE_STRIX_SCENARIO:?}" >&2
+		exit 8
+		;;
+esac
+EOF
+	chmod +x "$fake_strix"
+
+	# Scenario-specific source-tree setup so is_hallucinated_endpoint_finding()
+	# can locate "real" endpoints inside the self-contained temp workspace.
+	if [ "$scenario" = "vertex-primary-existing-endpoint-nonrecoverable" ]; then
+		echo 'GET /api/status' >"$workspace_dir/src/routes.txt"
+	elif [ "$scenario" = "multi-source-dirs-existing-endpoint" ]; then
+		# Endpoint lives in api/ (not src/), validating multi-dir scanning.
+		mkdir -p "$workspace_dir/api"
+		echo 'GET /api/status' >"$workspace_dir/api/routes.txt"
+	elif [ "$scenario" = "endpoint-in-excluded-dir" ]; then
+		# Endpoint /api/hidden-secret exists ONLY inside excluded directories
+		# (.git/ and node_modules/). The grep excludes must prevent matching,
+		# so the finding is treated as hallucinated → fallback allowed.
+		mkdir -p "$workspace_dir/.git/refs"
+		echo 'GET /api/hidden-secret' >"$workspace_dir/.git/refs/leaked.txt"
+		mkdir -p "$workspace_dir/node_modules/fake-pkg"
+		echo 'GET /api/hidden-secret' >"$workspace_dir/node_modules/fake-pkg/index.js"
+	fi
+
+	set +e
+	local env_cmd=(
+		PATH="$bin_dir:$PATH"
+		FAKE_STRIX_SCENARIO="$scenario"
+		FAKE_STRIX_CALL_LOG="$call_log"
+		FAKE_STRIX_API_BASE_LOG="$api_base_log"
+		STRIX_LLM="$initial_model"
+		STRIX_LLM_DEFAULT_PROVIDER="$default_provider"
+		LLM_API_KEY="dummy"
+		RAW_LLM_API_BASE="$raw_llm_api_base"
+		LLM_API_BASE="$initial_llm_api_base"
+		FAKE_STRIX_STATE_FILE="$state_file"
+		STRIX_TRANSIENT_RETRY_PER_MODEL="$transient_retry_per_model"
+		STRIX_TRANSIENT_RETRY_BACKOFF_SECONDS="$transient_retry_backoff_seconds"
+		STRIX_FAIL_ON_MIN_SEVERITY="$min_fail_severity"
+		STRIX_REPORTS_DIR="$workspace_dir/strix_runs"
+		STRIX_TARGET_PATH="$effective_target_path"
+	)
+	# Only export STRIX_VERTEX_FALLBACK_MODELS when a non-empty value is
+	# provided so that the gate's ${STRIX_VERTEX_FALLBACK_MODELS+x} check
+	# correctly distinguishes "unset → use defaults" from "set to empty →
+	# disable fallbacks".
+	if [ -n "$fallback_models" ]; then
+		env_cmd+=(STRIX_VERTEX_FALLBACK_MODELS="$fallback_models")
+	fi
+	if [ -n "$custom_source_dirs" ]; then
+		env_cmd+=(STRIX_SOURCE_DIRS="$custom_source_dirs")
+	fi
+	env "${env_cmd[@]}" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "$expected_exit" "$rc" "scenario=$scenario exit code"
+
+	if [ -n "$expected_message" ]; then
+		assert_file_contains "$output_log" "$expected_message" "scenario=$scenario output"
+	fi
+
+	local call_count
+	call_count="0"
+	if [ -f "$call_log" ]; then
+		call_count="$(wc -l <"$call_log" | tr -d ' ')"
+	fi
+	assert_equals "$expected_calls" "$call_count" "scenario=$scenario strix call count"
+
+	if [ -n "$expected_model_sequence" ]; then
+		local actual_model_sequence=""
+		if [ -f "$call_log" ]; then
+			while IFS= read -r model; do
+				if [ -n "$actual_model_sequence" ]; then
+					actual_model_sequence="${actual_model_sequence}|$model"
+				else
+					actual_model_sequence="$model"
+				fi
+			done <"$call_log"
+		fi
+
+		assert_equals "$expected_model_sequence" "$actual_model_sequence" "scenario=$scenario STRIX_LLM sequence"
+	fi
+
+	if [ -n "$expected_api_base_sequence" ]; then
+		local actual_api_base_sequence=""
+		if [ -f "$api_base_log" ]; then
+			while IFS= read -r api_base; do
+				if [ -n "$actual_api_base_sequence" ]; then
+					actual_api_base_sequence="${actual_api_base_sequence}|$api_base"
+				else
+					actual_api_base_sequence="$api_base"
+				fi
+			done <"$api_base_log"
+		fi
+
+		assert_equals "$expected_api_base_sequence" "$actual_api_base_sequence" "scenario=$scenario LLM_API_BASE sequence"
+	fi
+
+	rm -rf "$tmp_dir"
+}
+
+run_missing_config_case() {
+	local case_name="$1"
+	local strix_llm="$2"
+	local llm_api_key="$3"
+	local expected_message="$4"
+
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local call_count_file="$tmp_dir/strix_calls"
+	local fake_strix="$tmp_dir/strix"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "1" >> "${STRIX_CALL_COUNT_FILE:?}"
+exit 0
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="$strix_llm" \
+		LLM_API_KEY="$llm_api_key" \
+		STRIX_CALL_COUNT_FILE="$call_count_file" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "2" "$rc" "case=$case_name exit code"
+	assert_file_contains "$output_log" "$expected_message" "case=$case_name output"
+
+	local actual_calls="0"
+	if [ -f "$call_count_file" ]; then
+		actual_calls="$(wc -l <"$call_count_file" | tr -d ' ')"
+	fi
+	assert_equals "0" "$actual_calls" "case=$case_name strix call count"
+
+	rm -rf "$tmp_dir"
+}
+
+run_invalid_min_fail_severity_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local fake_strix="$tmp_dir/strix"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "unexpected strix execution" >&2
+exit 99
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="vertex_ai/ready-primary" \
+		LLM_API_KEY="dummy" \
+		STRIX_FAIL_ON_MIN_SEVERITY="BOGUS" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "2" "$rc" "case=invalid-min-fail-severity exit code"
+	assert_file_contains "$output_log" "STRIX_FAIL_ON_MIN_SEVERITY must be one of CRITICAL/HIGH/MEDIUM/LOW/INFO/INFORMATIONAL" "case=invalid-min-fail-severity output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_stale_report_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local fake_strix="$tmp_dir/strix"
+	local stale_report_dir="$tmp_dir/strix_runs/stale/vulnerabilities"
+
+	mkdir -p "$stale_report_dir"
+	cat >"$stale_report_dir/vuln-0001.md" <<'EOF'
+Severity: LOW
+EOF
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Error: transport timeout"
+exit 1
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="openai/gpt-4o-mini" \
+		LLM_API_KEY="dummy" \
+		RAW_LLM_API_BASE="https://example.invalid/generateContent" \
+		STRIX_REPORTS_DIR="$tmp_dir/strix_runs" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "1" "$rc" "case=stale-report-does-not-bypass exit code"
+	assert_file_contains "$output_log" "Strix quick scan failed with a non-recoverable error." "case=stale-report-does-not-bypass output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_symlink_report_case() {
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local output_log="$tmp_dir/output.log"
+	local fake_strix="$tmp_dir/strix"
+	local external_report_dir="$tmp_dir/external/vulnerabilities"
+
+	mkdir -p "$external_report_dir" "$tmp_dir/strix_runs"
+	cat >"$external_report_dir/vuln-0001.md" <<'EOF'
+Severity: LOW
+EOF
+	ln -s "$tmp_dir/external" "$tmp_dir/strix_runs/latest"
+
+	cat >"$fake_strix" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Error: transport timeout"
+exit 1
+EOF
+	chmod +x "$fake_strix"
+
+	set +e
+	PATH="$tmp_dir:$PATH" \
+		STRIX_LLM="openai/gpt-4o-mini" \
+		LLM_API_KEY="dummy" \
+		RAW_LLM_API_BASE="https://example.invalid/generateContent" \
+		STRIX_REPORTS_DIR="$tmp_dir/strix_runs" \
+		bash "$GATE_SCRIPT" >"$output_log" 2>&1
+	local rc=$?
+	set -e
+
+	assert_equals "1" "$rc" "case=symlink-report-does-not-bypass exit code"
+	assert_file_contains "$output_log" "Strix quick scan failed with a non-recoverable error." "case=symlink-report-does-not-bypass output"
+
+	rm -rf "$tmp_dir"
+}
+
+run_gate_case "success" \
+	"vertex_ai/ready-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok" \
+	"1" \
+	"vertex_ai/ready-primary" \
+	"<unset>"
+
+run_gate_case "vertex-primary-notfound-fallback-success" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-all-notfound" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Configured Vertex model and fallback models were unavailable." \
+	"3" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "nonrecoverable" \
+	"openai/gpt-4o-mini" \
+	"vertex_ai/fallback-one" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://example.invalid"
+
+run_gate_case "provider-prefix-required" \
+	"gemini-2.5-pro" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/gemini-2.5-pro'." \
+	"1" \
+	"vertex_ai/gemini-2.5-pro" \
+	"<unset>"
+
+run_gate_case "provider-prefix-fallback-normalization" \
+	"missing-primary" \
+	"fallback-one fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "provider-prefix-required-resource-path-primary-implicit-default-provider" \
+	"projects/p1/locations/us-central1/publishers/google/models/gemini-2.5-pro" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/gemini-2.5-pro'." \
+	"1" \
+	"vertex_ai/gemini-2.5-pro" \
+	"<unset>"
+
+run_gate_case "provider-prefix-required-resource-path-primary-explicit-empty-default-provider" \
+	"projects/p1/locations/us-central1/publishers/google/models/gemini-2.5-pro" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/gemini-2.5-pro'." \
+	"1" \
+	"vertex_ai/gemini-2.5-pro" \
+	"<unset>" \
+	""
+
+run_gate_case "provider-prefix-resource-path-primary-notfound-fallback-success" \
+	"projects/p1/locations/us-central1/publishers/google/models/missing-primary" \
+	"projects/p1/locations/us-central1/publishers/google/models/fallback-one projects/p1/locations/us-central1/publishers/google/models/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+# Regression: Vertex custom model resource path projects/<p>/locations/<l>/models/<id>
+# (no publishers/ segment) must be recognized as a Vertex resource path and
+# normalized to vertex_ai/<model_id>.
+run_gate_case "vertex-custom-model-resource-path" \
+	"projects/my-proj/locations/us-central1/models/my-custom-model-123" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Normalized STRIX_LLM to provider-qualified model 'vertex_ai/my-custom-model-123'." \
+	"1" \
+	"vertex_ai/my-custom-model-123" \
+	"<unset>"
+
+run_gate_case "vertex-notfound-without-status-fallback-success" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-notfound-compact-status-fallback-success" \
+	"vertex_ai/missing-primary" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "nonvertex-slash-model-passthrough" \
+	"foo/bar" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"scan ok with non-vertex slash model passthrough" \
+	"1" \
+	"foo/bar" \
+	"https://example.invalid"
+
+run_gate_case "primary-duplicate-in-fallback" \
+	"missing-primary" \
+	"vertex_ai/missing-primary fallback-one" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "multiline-fallback-success" \
+	"vertex_ai/missing-primary" \
+	$'vertex_ai/fallback-one\nvertex_ai/fallback-two' \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-two'." \
+	"3" \
+	"vertex_ai/missing-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "vertex-primary-ratelimit-fallback-success" \
+	"vertex_ai/ratelimit-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/ratelimit-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-resource-exhausted-fallback-success" \
+	"vertex_ai/resource-exhausted-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/resource-exhausted-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-429-fallback-success" \
+	"vertex_ai/http429-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/http429-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-midstream-fallback-success" \
+	"vertex_ai/midstream-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/midstream-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-midstream-retry-same-model-success" \
+	"vertex_ai/retry-midstream-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model retry" \
+	"2" \
+	"vertex_ai/retry-midstream-primary|vertex_ai/retry-midstream-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Bug 9: Rate-limit transient same-model retry (previously untested path)
+run_gate_case "vertex-primary-ratelimit-retry-same-model-success" \
+	"vertex_ai/retry-ratelimit-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model rate-limit retry" \
+	"2" \
+	"vertex_ai/retry-ratelimit-primary|vertex_ai/retry-ratelimit-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Bug 11: Timeout transient same-model retry (timeout was not retried with same model)
+run_gate_case "vertex-primary-timeout-retry-same-model-success" \
+	"vertex_ai/retry-timeout-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after same-model timeout retry" \
+	"2" \
+	"vertex_ai/retry-timeout-primary|vertex_ai/retry-timeout-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Bug 11b: Timeout → retries exhausted → fallback model succeeds.
+# Primary always times out; after 1 same-model retry is exhausted, gate falls
+# back to the next Vertex model which succeeds.
+run_gate_case "vertex-primary-timeout-exhausted-fallback-success" \
+	"vertex_ai/timeout-exhaust-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after timeout-exhausted fallback" \
+	"3" \
+	"vertex_ai/timeout-exhaust-primary|vertex_ai/timeout-exhaust-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_gate_case "vertex-all-ratelimited" \
+	"vertex_ai/ratelimit-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Configured Vertex model and fallback models were unavailable." \
+	"3" \
+	"vertex_ai/ratelimit-primary|vertex_ai/fallback-one|vertex_ai/fallback-two" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "vertex-primary-hallucinated-endpoint-fallback-success" \
+	"vertex_ai/hallucination-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/hallucination-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+run_gate_case "vertex-primary-existing-endpoint-nonrecoverable" \
+	"vertex_ai/existing-endpoint-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/existing-endpoint-primary" \
+	"<unset>"
+
+run_gate_case "high-vuln-below-threshold" \
+	"vertex_ai/high-vuln-primary" \
+	"" \
+	"0" \
+	"below configured fail threshold 'CRITICAL'" \
+	"1" \
+	"vertex_ai/high-vuln-primary" \
+	"<unset>"
+
+# Infrastructure error guard: below-threshold findings must NOT pass when the
+# strix log contains evidence of infrastructure-level errors (timeout,
+# rate-limit, transport failures) because the scan was likely incomplete.
+
+# Guard test 1: LOW finding + timeout → should fail (exit 1).
+# The below-threshold check runs first but detects infrastructure errors in the
+# strix log and refuses bypass.  The timeout is also vertex-retryable, so the
+# gate continues into the fallback loop.  All attempts see the same timeout.
+run_gate_case "below-threshold-with-timeout" \
+	"vertex_ai/low-timeout-primary" \
+	"vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash" \
+	"1" \
+	"infrastructure errors occurred during this pipeline run; refusing bypass" \
+	"3" \
+	"vertex_ai/low-timeout-primary|vertex_ai/gemini-2.5-pro|vertex_ai/gemini-2.5-flash" \
+	"<unset>|<unset>|<unset>"
+
+# Guard test 2: LOW finding + rate-limit → should fail (exit 1).
+# Below-threshold check refuses bypass due to infra errors.
+# Rate-limit is vertex-retryable, so the gate also tries fallback models.
+run_gate_case "below-threshold-with-ratelimit" \
+	"vertex_ai/low-ratelimit-primary" \
+	"vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash" \
+	"1" \
+	"infrastructure errors occurred during this pipeline run; refusing bypass" \
+	"3" \
+	"vertex_ai/low-ratelimit-primary|vertex_ai/gemini-2.5-pro|vertex_ai/gemini-2.5-flash" \
+	"<unset>|<unset>|<unset>"
+
+# Guard test 3: INFO finding + ConnectionError → should fail (exit 1).
+# ConnectionError is NOT vertex-retryable, so only the primary model is tried.
+run_gate_case "below-threshold-with-connection-error" \
+	"vertex_ai/info-conn-primary" \
+	"" \
+	"1" \
+	"infrastructure errors occurred during this pipeline run; refusing bypass" \
+	"1" \
+	"vertex_ai/info-conn-primary" \
+	"<unset>"
+
+# Guard test 3b: INFO finding + ConnectionError WITHOUT provider marker → should
+# PASS (exit 0).  The two-grep infra-error detector requires both a transport
+# error class AND an LLM_PROVIDER_ONLY_REGEX marker (litellm, openai,
+# anthropic, VertexAI, etc.).  Note: transport libraries (requests, httpx,
+# httpcore) are intentionally excluded from LLM_PROVIDER_ONLY_REGEX to avoid
+# false positives — see guard test 3c below.
+# A bare "ConnectionError" from the target application lacks the marker, so
+# has_detected_infrastructure_error() returns 1 (no infra error) and the
+# below-threshold bypass succeeds.
+run_gate_case "below-threshold-with-connection-error-no-provider" \
+	"vertex_ai/info-conn-noprov-primary" \
+	"" \
+	"0" \
+	"below configured fail threshold" \
+	"1" \
+	"vertex_ai/info-conn-noprov-primary" \
+	"<unset>"
+
+# Guard test 3c: INFO finding + requests.exceptions.ConnectionError → should
+# PASS (exit 0).  The "requests" transport library matches the broad
+# PROVIDER_CONTEXT_REGEX but is intentionally excluded from LLM_PROVIDER_ONLY_REGEX.
+# Before commit 0e90d48 the connection-error path used PROVIDER_CONTEXT_REGEX
+# and would have mis-classified this as an LLM infrastructure error; now it
+# correctly uses LLM_PROVIDER_ONLY_REGEX, so below-threshold bypass succeeds.
+run_gate_case "below-threshold-with-requests-connection-error" \
+	"vertex_ai/info-conn-requests-primary" \
+	"" \
+	"0" \
+	"below configured fail threshold" \
+	"1" \
+	"vertex_ai/info-conn-requests-primary" \
+	"<unset>"
+
+# Guard test 4: MEDIUM finding + MidStreamFallbackError → should fail (exit 1).
+# Midstream is vertex-retryable, so the gate also tries fallback models
+# (after the below-threshold check refuses bypass due to infra errors).
+run_gate_case "below-threshold-with-midstream" \
+	"vertex_ai/medium-midstream-primary" \
+	"vertex_ai/gemini-2.5-pro vertex_ai/gemini-2.5-flash" \
+	"1" \
+	"infrastructure errors occurred during this pipeline run; refusing bypass" \
+	"3" \
+	"vertex_ai/medium-midstream-primary|vertex_ai/gemini-2.5-pro|vertex_ai/gemini-2.5-flash" \
+	"<unset>|<unset>|<unset>"
+
+run_gate_case "critical-vuln-at-threshold" \
+	"vertex_ai/critical-vuln-primary" \
+	"" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/critical-vuln-primary" \
+	"<unset>"
+
+run_gate_case "malformed-severity-marker-nonrecoverable" \
+	"vertex_ai/malformed-severity-primary" \
+	"" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/malformed-severity-primary" \
+	"<unset>"
+
+# Bug 7: Model disagreement — primary produces CRITICAL, fallback produces LOW.
+# The CRITICAL from the earlier report must NOT be ignored.
+# Both models produce NOT_FOUND errors, so the gate exhausts fallbacks and
+# reports "Configured Vertex model and fallback models were unavailable."
+# The key assertion is exit 1: the CRITICAL finding is NOT downgraded to pass.
+run_gate_case "model-disagreement-critical-in-earlier-report" \
+	"vertex_ai/model-a" \
+	"vertex_ai/model-b" \
+	"1" \
+	"Configured Vertex model and fallback models were unavailable." \
+	"2" \
+	"vertex_ai/model-a|vertex_ai/model-b" \
+	"<unset>|<unset>"
+
+# Bug 4: deepseek/models/deepseek-r1 must NOT be rewritten to vertex_ai/deepseek-r1
+run_gate_case "nonvertex-slash-model-not-rewritten" \
+	"deepseek/models/deepseek-r1" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"scan ok with deepseek model passthrough" \
+	"1" \
+	"deepseek/models/deepseek-r1" \
+	"https://example.invalid"
+
+# Regression: STRIX_TARGET_PATH=<dir>/src with default STRIX_SOURCE_DIRS (now ".")
+# must resolve to <dir>/src/. (i.e. <dir>/src itself), NOT <dir>/src/src.
+# The hallucinated-endpoint scenario writes a vuln report with a fake endpoint;
+# the gate should detect it's absent from source and trigger fallback — which
+# requires the source dir to actually exist and be scanned.
+run_gate_case "target-path-src-default-source-dirs" \
+	"vertex_ai/hallucination-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/fallback-one'." \
+	"2" \
+	"vertex_ai/hallucination-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1" \
+	"CRITICAL" \
+	"0" \
+	"__USE_SUBDIR_SRC__" \
+	""
+
+# Bug 2 follow-up: multi-entry STRIX_SOURCE_DIRS test.
+# Endpoint /api/status lives in api/ (not src/).  With STRIX_SOURCE_DIRS="src api"
+# the gate must find the endpoint in the api/ dir and treat the finding as
+# non-hallucinated → non-recoverable failure (exit 1).
+run_gate_case "multi-source-dirs-existing-endpoint" \
+	"vertex_ai/multi-dir-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"1" \
+	"Strix quick scan failed with a non-recoverable error." \
+	"1" \
+	"vertex_ai/multi-dir-primary" \
+	"<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"0" \
+	"CRITICAL" \
+	"0" \
+	"" \
+	"src api"
+
+run_gate_case "preserve-existing-api-base" \
+	"openai/gpt-4o-mini" \
+	"" \
+	"0" \
+	"scan ok with preserved api base" \
+	"1" \
+	"openai/gpt-4o-mini" \
+	"https://preexisting.invalid" \
+	"vertex_ai" \
+	"" \
+	"https://preexisting.invalid"
+
+run_gate_case "default-fallback-order-fast-first" \
+	"vertex_ai/missing-primary" \
+	"" \
+	"0" \
+	"Strix quick scan succeeded with fallback model 'vertex_ai/gemini-2.5-pro'." \
+	"2" \
+	"vertex_ai/missing-primary|vertex_ai/gemini-2.5-pro" \
+	"<unset>|<unset>"
+
+# Bug 13: All fallback models are the same as the primary model.
+# The gate should detect that no distinct fallback was tried and emit an ERROR.
+run_gate_case "all-fallbacks-same-as-primary" \
+	"vertex_ai/same-primary" \
+	"vertex_ai/same-primary vertex_ai/same-primary" \
+	"1" \
+	"ERROR: All configured fallback models are the same as the primary model" \
+	"1" \
+	"vertex_ai/same-primary" \
+	"<unset>"
+
+# Bug 14: Retry reason messages — timeout retry should say "due to timeout".
+run_gate_case "vertex-primary-timeout-retry-reason-message" \
+	"vertex_ai/retry-timeout-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"due to timeout" \
+	"2" \
+	"vertex_ai/retry-timeout-primary|vertex_ai/retry-timeout-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"2"
+
+# Bug 14: Retry reason messages — rate-limit retry should say "due to rate limit".
+run_gate_case "vertex-primary-ratelimit-retry-reason-message" \
+	"vertex_ai/retry-ratelimit-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"due to rate limit" \
+	"2" \
+	"vertex_ai/retry-ratelimit-primary|vertex_ai/retry-ratelimit-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"2"
+
+# Bug 14: Timing message — success should log elapsed time.
+run_gate_case "vertex-primary-success-timing-message" \
+	"vertex_ai/ready-primary" \
+	"" \
+	"0" \
+	"Strix run succeeded for model 'vertex_ai/ready-primary' in " \
+	"1" \
+	"vertex_ai/ready-primary" \
+	"<unset>"
+
+# is_timeout_error() provider-context marker test:
+# Bare "Connection timed out" without any LLM provider marker should NOT
+# be treated as a timeout error. The gate should fail without retrying.
+# The fake strix now also emits "httpx", "httpcore", and "requests" strings
+# to verify that transport library names alone do NOT qualify as provider markers.
+# Model name deliberately avoids containing any provider marker string
+# (litellm, openai, anthropic, VertexAI, vertex.ai, google.cloud).
+run_gate_case "bare-timeout-no-provider-marker" \
+	"custom/bare-timeout-model" \
+	"" \
+	"1" \
+	"" \
+	"1" \
+	"custom/bare-timeout-model" \
+	"https://example.invalid" \
+	"custom" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# is_timeout_error() Tier 2: httpx.ReadTimeout + provider-context marker.
+# The middle tier classifies httpx transport timeouts as retryable when
+# accompanied by a provider-context marker (PROVIDER_CONTEXT_REGEX).
+# First call times out with httpx.ReadTimeout → same-model retry succeeds.
+run_gate_case "httpx-read-timeout-with-provider-marker" \
+	"vertex_ai/httpx-timeout-primary" \
+	"" \
+	"0" \
+	"scan ok after httpx-timeout retry" \
+	"2" \
+	"vertex_ai/httpx-timeout-primary|vertex_ai/httpx-timeout-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Negative: httpx.ReadTimeout WITHOUT provider-context marker should NOT
+# be classified as a retryable timeout (the gate should treat it as a
+# non-recoverable scan failure).
+run_gate_case "httpx-read-timeout-no-provider-marker" \
+	"custom/httpx-timeout-no-ctx" \
+	"" \
+	"1" \
+	"non-recoverable error" \
+	"1" \
+	"custom/httpx-timeout-no-ctx" \
+	"https://example.invalid" \
+	"custom" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# is_timeout_error() Tier 2b: httpcore.ReadTimeout + provider-context marker.
+# Mirrors the httpx.ReadTimeout positive case above, using httpcore instead.
+# First call times out with httpcore.ReadTimeout → same-model retry succeeds.
+run_gate_case "httpcore-read-timeout-with-provider-marker" \
+	"vertex_ai/httpcore-timeout-primary" \
+	"" \
+	"0" \
+	"scan ok after httpcore-timeout retry" \
+	"2" \
+	"vertex_ai/httpcore-timeout-primary|vertex_ai/httpcore-timeout-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Negative: httpcore.ReadTimeout WITHOUT provider-context marker should NOT
+# be classified as a retryable timeout (the gate should treat it as a
+# non-recoverable scan failure).
+run_gate_case "httpcore-read-timeout-no-provider-marker" \
+	"custom/httpcore-timeout-no-ctx" \
+	"" \
+	"1" \
+	"non-recoverable error" \
+	"1" \
+	"custom/httpcore-timeout-no-ctx" \
+	"https://example.invalid" \
+	"custom" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# is_timeout_error() positive branch for "Connection timed out" + provider marker:
+# When "Connection timed out" appears alongside an LLM provider marker (e.g.
+# litellm, vertex_ai), the gate should classify it as a retryable timeout.
+# First call times out with provider context → same-model retry succeeds.
+run_gate_case "bare-timeout-with-provider-marker" \
+	"vertex_ai/bare-timeout-primary" \
+	"" \
+	"0" \
+	"scan ok after bare-timeout-with-provider retry" \
+	"2" \
+	"vertex_ai/bare-timeout-primary|vertex_ai/bare-timeout-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Bare "Connection timed out" + provider marker: primary exhausts all retries,
+# then gate falls back to fallback-one which succeeds.
+# Expected: primary(fail) → retry(fail) → fallback-one(success) = 3 calls, exit 0.
+run_gate_case "bare-timeout-provider-marker-exhausted-fallback" \
+	"vertex_ai/bare-timeout-exhaust-primary" \
+	"vertex_ai/fallback-one" \
+	"0" \
+	"scan ok after bare-timeout-exhaust fallback" \
+	"3" \
+	"vertex_ai/bare-timeout-exhaust-primary|vertex_ai/bare-timeout-exhaust-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+# Sticky INFRA_ERROR_DETECTED flag: first call hits rate-limit (infra error),
+# second call fails with a non-retryable error but leaves a partial LOW report.
+# The gate must refuse the below-threshold bypass because an infrastructure
+# error was detected during this pipeline run.
+run_gate_case "infra-error-sticky-flag" \
+	"vertex_ai/sticky-flag-primary" \
+	"" \
+	"1" \
+	"infrastructure errors occurred" \
+	"2" \
+	"vertex_ai/sticky-flag-primary|vertex_ai/sticky-flag-primary" \
+	"<unset>|<unset>" \
+	"vertex_ai" \
+	"__DEFAULT__" \
+	"" \
+	"1"
+
+run_invalid_min_fail_severity_case
+run_stale_report_case
+run_symlink_report_case
+
+run_missing_config_case "missing-strix-llm" "" "dummy" "ERROR: STRIX_LLM is required."
+run_missing_config_case "missing-llm-api-key" "vertex_ai/ready-primary" "" "ERROR: LLM_API_KEY is required."
+run_missing_config_case "whitespace-only-strix-llm" "   " "dummy" "ERROR: STRIX_LLM is required."
+run_missing_config_case "whitespace-only-llm-api-key" "vertex_ai/ready-primary" $'\t  ' "ERROR: LLM_API_KEY is required."
+
+# ── Segment boundary enforcement for is_vertex_resource_path / extract_vertex_model_id ──
+# Shell glob '*' matches '/' so the old case-pattern implementation accepted
+# malformed paths with extra segments (e.g. "projects/a/b/locations/…").
+# These tests verify that only paths with the exact expected segment count match.
+#
+# The gate script cannot be sourced directly (it has top-level side effects),
+# so we extract the two functions via sed and eval them in this shell.
+_vertex_funcs="$(sed -n '/^is_vertex_resource_path()/,/^}/p; /^extract_vertex_model_id()/,/^}/p' "$GATE_SCRIPT")"
+eval "$_vertex_funcs"
+
+assert_vertex_path() {
+	local label="$1" path="$2" expect_rc="$3"
+	local actual_rc
+	if is_vertex_resource_path "$path"; then
+		actual_rc=0
+	else
+		actual_rc=1
+	fi
+	if [ "$actual_rc" -ne "$expect_rc" ]; then
+		echo "FAIL: is_vertex_resource_path($label): got rc=$actual_rc want $expect_rc" >&2
+		FAILURES=$((FAILURES + 1))
+	fi
+}
+
+assert_vertex_extract() {
+	local label="$1" path="$2" expected="$3"
+	local actual
+	actual="$(extract_vertex_model_id "$path")"
+	if [ "$actual" != "$expected" ]; then
+		echo "FAIL: extract_vertex_model_id($label): got '$actual' want '$expected'" >&2
+		FAILURES=$((FAILURES + 1))
+	fi
+}
+
+# Valid paths — should return 0
+assert_vertex_path "models/<id>" "models/gemini-2.5-pro" 0
+assert_vertex_path "publishers/<p>/models/<id>" "publishers/google/models/gemini-2.5-pro" 0
+assert_vertex_path "projects/<p>/locations/<l>/models/<id>" "projects/my-proj/locations/us-central1/models/gemini-2.5-pro" 0
+assert_vertex_path "projects/<p>/locations/<l>/publishers/<pub>/models/<id>" "projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro" 0
+
+# Malformed paths — extra segments that '*' used to match across '/'
+assert_vertex_path "extra-segment-in-project" "projects/a/b/locations/us/models/foo" 1
+assert_vertex_path "extra-segment-in-location" "projects/a/locations/b/c/models/foo" 1
+assert_vertex_path "extra-segment-in-publisher" "projects/a/locations/b/publishers/c/d/models/foo" 1
+assert_vertex_path "extra-segment-after-models" "projects/a/locations/b/models/foo/bar" 1
+assert_vertex_path "empty-model-id" "models/" 1
+assert_vertex_path "empty-project" "projects//locations/us/models/foo" 1
+assert_vertex_path "plain-model-name" "gemini-2.5-pro" 1
+assert_vertex_path "non-vertex-provider-slash" "deepseek/models/deepseek-r1" 1
+assert_vertex_path "empty-string" "" 1
+
+# extract_vertex_model_id — valid paths
+assert_vertex_extract "models/<id>" "models/gemini-2.5-pro" "gemini-2.5-pro"
+assert_vertex_extract "publishers/<p>/models/<id>" "publishers/google/models/gemini-2.5-pro" "gemini-2.5-pro"
+assert_vertex_extract "projects/<p>/locations/<l>/models/<id>" "projects/my-proj/locations/us-central1/models/gemini-2.5-pro" "gemini-2.5-pro"
+assert_vertex_extract "projects/…/publishers/…/models/<id>" "projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro" "gemini-2.5-pro"
+
+# extract_vertex_model_id — non-vertex paths return as-is
+assert_vertex_extract "non-vertex-passthrough" "deepseek/models/deepseek-r1" "deepseek/models/deepseek-r1"
+assert_vertex_extract "plain-model-passthrough" "gemini-2.5-pro" "gemini-2.5-pro"
+
+# Whitespace in paths — must be rejected (SAST word-splitting guard)
+assert_vertex_path "space-in-project" "projects/my proj/locations/us/models/foo" 1
+assert_vertex_path "tab-in-model-id" $'models/gemini\t2.5' 1
+assert_vertex_extract "space-passthrough" "models/my model" "models/my model"
+
+# Endpoint only exists in excluded directories (.git/, node_modules/).
+# The grep --exclude-dir patterns must prevent matching, so the finding
+# is treated as hallucinated and fallback is allowed → exit 0.
+run_gate_case "endpoint-in-excluded-dir" \
+	"vertex_ai/excluded-dir-primary" \
+	"vertex_ai/fallback-one vertex_ai/fallback-two" \
+	"0" \
+	"scan ok after excluded-dir hallucination fallback" \
+	"2" \
+	"vertex_ai/excluded-dir-primary|vertex_ai/fallback-one" \
+	"<unset>|<unset>"
+
+# Whitespace-only fallback models: STRIX_VERTEX_FALLBACK_MODELS set to "  ".
+# This bypasses the :- default but produces an empty array from read -r -a.
+# The gate should emit "No fallback models configured" (not the misleading
+# "All configured fallback models are the same as the primary model").
+run_gate_case "empty-fallback-models" \
+	"vertex_ai/empty-fb-primary" \
+	"   " \
+	"1" \
+	"No fallback models configured" \
+	"1" \
+	"vertex_ai/empty-fb-primary" \
+	"<unset>"
+
+if [ "$FAILURES" -ne 0 ]; then
+	echo "test_strix_quick_gate: ${FAILURES} failure(s)" >&2
+	exit 1
+fi
+
+echo "test_strix_quick_gate: PASS"


### PR DESCRIPTION
## Summary

Sync all 3 Strix pipeline files from dns-guard develop canonical:
- **strix.yml**: timeout removal, STRIX_TARGET_PATH=./
- **strix_quick_gate.sh**: sticky INFRA_ERROR_DETECTED flag, signal traps, grep hardening
- **test_strix_quick_gate.sh**: updated test scenarios

This is an automated deployment from the dns-guard canonical pipeline.